### PR TITLE
feature/provide hopla config file

### DIFF
--- a/hopla/add/todo
+++ b/hopla/add/todo
@@ -6,6 +6,8 @@ set -o errexit
 source "${library_dir}/api_proxy.sh"
 source "${library_dir}/logging.sh"
 
+# TODO: the $@ splitting here causes the "todo   name" to be interpreted as "todo name"
+#       Consider if this is a feature or a bug
 readonly args=($@)
 
 cur_arg=0

--- a/hopla/add/todo.help
+++ b/hopla/add/todo.help
@@ -9,8 +9,14 @@ usage:
 
 Examples:
 ```bash
+# using $(date '+Y-%m-%d') as the due date will result in the due-date being set to 'today'
 hopla add todo --hard --due-date $(date '+%Y-%m-%d') "Feed pet"
+
+# --due-date and --deadline work as synonyms
 hopla add todo --easy --checklist ~/my/absolute_file.txt "My Important Project"
+hopla add todo --easy --due-date  ~/my/absolute_file.txt "My Important Project"
+
+# when no --trivial, --easy, --medium, --hard is used, --medium is the default
 hopla add todo --checklist <(sort ./tasks.txt) "Sorted Checklist"
 ```
 

--- a/hopla/hopla
+++ b/hopla/hopla
@@ -73,7 +73,7 @@ read_credentials
 
 
 handle_global_options() {
-  if [[ "$1" == "--help" ]]; then
+  if [[ "${1:-"--help"}" == "--help" ]]; then
     cat "${script_dirname}/hopla.help"
     exit 0
   fi

--- a/hopla/hopla
+++ b/hopla/hopla
@@ -54,8 +54,11 @@ debug "config_file_path: ${config_file_path}"
 read_configs() {
   debug "read_configs"
   if [[ -f ${config_file_path} ]]; then
-    source "${config_file_path}"
-    # TODO: export the variables that are read here
+    while read -r config_setting ; do
+      # we want to export every line of the config file
+      # shellcheck disable=SC2163
+      export "${config_setting}"
+    done < "${config_file_path}"
   else
     debug "config file ${config_file_path} is not a file"
   fi

--- a/hopla/hopla
+++ b/hopla/hopla
@@ -24,9 +24,9 @@ source "${library_dir}/logging.sh"
 
 print_hopla_auth_file() {
   local file_path=
-  if [[ -n "${HOPLA_AUTH_FILE-}" && -f "${HOPLA_AUTH_FILE-}" ]] ; then
+  if [[ -n "${HOPLA_AUTH_FILE:-}" && -f "${HOPLA_AUTH_FILE:-}" ]] ; then
     file_path="${HOPLA_AUTH_FILE}"
-  elif [[ -n "${XDG_DATA_HOME-}" && -d "${XDG_DATA_HOME-}" ]] ; then
+  elif [[ -n "${XDG_DATA_HOME:-}" && -d "${XDG_DATA_HOME:-}" ]] ; then
     file_path="${XDG_DATA_HOME}/hopla/auth.conf"
   else
     file_path="${HOME}/.local/share/hopla/auth.conf"
@@ -39,10 +39,10 @@ debug "auth_file_path ${auth_file_path}"
 
 print_hopla_config_file() {
   local file_path=
-  if [[ -n "${HOPLA_CONFIG_FILE-}" && -f "${HOPLA_CONFIG_FILE-}" ]] ; then
+  if [[ -n "${HOPLA_CONFIG_FILE:-}" && -f "${HOPLA_CONFIG_FILE:-}" ]] ; then
     file_path="${HOPLA_CONFIG_FILE}"
-  elif [[ -n "${XDG_CONFIG_HOME-}" && -d "${XDG_CONFIG_HOME-}" ]] ; then
-    file_path="${XDG_CONFIG_HOME}/auth.conf"
+  elif [[ -n "${XDG_CONFIG_HOME:-}" && -d "${XDG_CONFIG_HOME:-}" ]] ; then
+    file_path="${XDG_CONFIG_HOME}/hopla/hopla.conf"
   else
     file_path="${HOME}/.config/hopla/hopla.conf"
   fi
@@ -51,6 +51,16 @@ print_hopla_config_file() {
 declare -xr config_file_path=$(print_hopla_config_file)
 debug "config_file_path: ${config_file_path}"
 
+read_configs() {
+  debug "read_configs"
+  if [[ -f ${config_file_path} ]]; then
+    source "${config_file_path}"
+    # TODO: export the variables that are read here
+  else
+    debug "config file ${config_file_path} is not a file"
+  fi
+}
+read_configs
 
 read_credentials() {
   debug "read_credentials"

--- a/hopla/set/config
+++ b/hopla/set/config
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+source "${library_dir}/logging.sh"
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+
+readonly args=($@)
+
+readonly config_key="${args[0]:?"missing config_key and config_value"}"
+readonly config_value="${args[1]:?"missing config_value"}"
+
+
+
+create_config_file() {
+  debug "create_config_file"
+  local config_dir_name=${config_file_path%/*}
+  mkdir --parents "${config_dir_name}"
+  touch "${config_file_path}"
+
+  echo "created an configuration file called '${config_file_path}'"
+  echo "If you want to use another file, set an environment variable called HOPLA_CONFIG_FILE."
+}
+
+add_configuration_to_config_file() {
+  debug "add_configuration_to_config_file"
+
+  # TODO: implement replacement of pre-existing configuration
+  echo "${config_key}=${config_value}" >> "${config_file_path}"
+}
+
+
+main() {
+  if [[ ! -f ${config_file_path} ]] ; then
+      create_config_file
+  fi
+  add_configuration_to_config_file
+}
+main
+
+
+

--- a/hopla/set/config.help
+++ b/hopla/set/config.help
@@ -1,0 +1,11 @@
+hopla set config - set personalized settings in the configuration file
+
+usage:
+    hopla set config {config_key} {config_value}
+
+
+Example
+```bash
+# enable debug logging to console
+hopla set config debug_enabled 1
+```

--- a/hopla/set/credentials
+++ b/hopla/set/credentials
@@ -5,11 +5,11 @@ source "${library_dir}/logging.sh"
 create_auth_file() {
   debug "create_auth_file"
   auth_dir_name=${auth_file_path%/*}
-  mkdir -p "${auth_dir_name}"
+  mkdir --parents "${auth_dir_name}"
   touch "${auth_file_path}"
 
   echo "created an authentication file called '${auth_file_path}'"
-  echo 'If you want to use another file, set an environment variable called HOPLA_AUTH_FILE.'
+  echo "If you want to use another file, set an environment variable called HOPLA_AUTH_FILE."
 }
 
 write_credential_file() {

--- a/hopla/set/credentials
+++ b/hopla/set/credentials
@@ -12,11 +12,6 @@ create_auth_file() {
   echo 'If you want to use another file, set an environment variable called HOPLA_AUTH_FILE.'
 }
 
-if [[ ! -f ${auth_file_path} ]] ; then
-  create_auth_file
-fi
-
-
 write_credential_file() {
   debug "write_credential_file"
 
@@ -26,6 +21,14 @@ write_credential_file() {
   echo "auth_file_user_id=${habitica_user_id}"     >  "${auth_file_path}"
   echo "auth_file_api_token=${habitica_api_token}" >> "${auth_file_path}"
 }
-write_credential_file
+
+main() {
+  if [[ ! -f ${auth_file_path} ]] ; then
+    create_auth_file
+  fi
+
+  write_credential_file
+}
+main
 
 

--- a/hopla/set/credentials
+++ b/hopla/set/credentials
@@ -4,7 +4,7 @@ source "${library_dir}/logging.sh"
 
 create_auth_file() {
   debug "create_auth_file"
-  auth_dir_name=${auth_file_path%/*}
+  local auth_dir_name=${auth_file_path%/*}
   mkdir --parents "${auth_dir_name}"
   touch "${auth_file_path}"
 

--- a/library/logging.sh
+++ b/library/logging.sh
@@ -1,12 +1,6 @@
 #!/usr/bin/env bash
 
-development=1
-if [[ "${development}" == 1 ]] ; then
-  debug_enabled=1
-#  set -x
-else
-  debug_enabled=0
-fi
+debug_enabled="${debug_enabled:-0}"
 
 debug () {
   message="$1"


### PR DESCRIPTION
- when invoking `hopla` without args: provide the help page instead of failing
- add an unrelated TODO statement for later
- added the "hopla set config {key} {value}" command
- finished configuration and have the first configuration key working: debug_enabled
