### PR TITLE
feature/85 add feed until out of food option

### DIFF
--- a/src/hopla/__init__.py
+++ b/src/hopla/__init__.py
@@ -9,7 +9,7 @@ import click
 from hopla.cli.authenticate import authenticate
 from hopla.cli.complete import complete
 from hopla.cli.config import config
-from hopla.cli.feed import feed
+from hopla.cli.feed import feed, feed_all
 from hopla.cli.get_group import get_group
 from hopla.cli.get_user.auth import auth
 from hopla.cli.get_user.info import info
@@ -95,6 +95,7 @@ def organize_cli():
     hopla.add_command(version)
     hopla.add_command(authenticate)
     hopla.add_command(feed)
+    hopla.add_command(feed_all)
     hopla.add_command(support_development)
     hopla.add_command(request)
     hopla.add_command(get_group)

--- a/src/hopla/__init__.py
+++ b/src/hopla/__init__.py
@@ -9,7 +9,8 @@ import click
 from hopla.cli.authenticate import authenticate
 from hopla.cli.complete import complete
 from hopla.cli.config import config
-from hopla.cli.feed import feed, feed_all
+from hopla.cli.feed import feed
+from hopla.cli.feed_all import feed_all
 from hopla.cli.get_group import get_group
 from hopla.cli.get_user.auth import auth
 from hopla.cli.get_user.info import info

--- a/src/hopla/cli/feed.py
+++ b/src/hopla/cli/feed.py
@@ -75,6 +75,7 @@ def get_appropriate_food_or_exit(pet_name: str) -> Union[str, NoReturn]:
         stockpile: FoodStockpile = FoodStockpileBuilder().user(user).build()
         return stockpile.get_most_abundant_food()
 
+    # This should be unreachable if we configured click with the correct pets.
     msg = (f"We tried to find the appropriate food for {pet_name=}.\n"
            "We assumed that we would have found the appropriate food by now.\n"
            "Unfortunately, that was not the case.")

--- a/src/hopla/cli/feed.py
+++ b/src/hopla/cli/feed.py
@@ -115,7 +115,7 @@ _UNTIL_MOUNT_OPTION = "--until-mount"
 def feed(pet_name: str, food_name: str,
          times: int, until_mount: bool,
          list_favorite_food: bool):
-    """Feed a pet.
+    """Feed a single pet.
 
      \b
      PET_NAME   name of the pet (e.g. Wolf-Golden)

--- a/src/hopla/cli/feed_all.py
+++ b/src/hopla/cli/feed_all.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""
+The module with CLI code that handles the `hopla feed-all` command.
+"""
+import logging
+import sys
+from typing import NoReturn, Optional, Union
+
+import click
+import requests
+
+from hopla.cli.groupcmds.get_user import HabiticaUser, HabiticaUserRequest
+from hopla.hoplalib.zoo.feeding_clickhelper import get_feed_data_or_exit
+from hopla.hoplalib.zoo.foodmodels import FoodStockpile, FoodStockpileBuilder
+from hopla.hoplalib.zoo.petcontroller import FeedPostRequester
+from hopla.hoplalib.zoo.petmodels import Zoo, ZooBuilder
+from hopla.hoplalib.zoo.zoofeeding_algorithms import ZooFeedingAlgorithm, ZookeeperFeedPlan
+
+log = logging.getLogger()
+
+
+def __get_feeding_plan_or_exit() -> Union[NoReturn, ZookeeperFeedPlan]:
+    """Get the user and build the zookeeper plan"""
+    user: HabiticaUser = HabiticaUserRequest().request_user_data_or_exit()
+    stockpile: FoodStockpile = FoodStockpileBuilder().user(user).build()
+    zoo: Zoo = ZooBuilder(user).build()
+
+    algorithm = ZooFeedingAlgorithm(zoo=zoo, stockpile=stockpile)
+    return algorithm.make_plan()
+
+
+def __confirm_with_user_or_abort(plan: ZookeeperFeedPlan) -> Optional[NoReturn]:
+    """Ask the user to confirm the specified plan.
+
+    :param plan: the zookeeper feeding plan to display
+    :return: Don't return if the user wants to abort
+    """
+
+    prompt_msg = f"{plan.format_plan()}Do you want to proceed?"
+    click.confirm(text=prompt_msg, abort=True)
+
+
+def feed_all_pets_and_exit() -> NoReturn:
+    """Feed all the pets"""
+    plan: ZookeeperFeedPlan = __get_feeding_plan_or_exit()
+    if plan.isempty():
+        click.echo(
+            "The feed plan is empty. Reasons could include:\n"
+            "1. There is insufficient food available to turn pets into mounts\n"
+            "2. You don't have any feedable pets."
+        )
+        sys.exit(0)
+
+    __confirm_with_user_or_abort(plan)
+
+    for item in plan:
+        request = FeedPostRequester(pet_name=item.pet_name,
+                                    food_name=item.food_name,
+                                    food_amount=item.times)
+        response: requests.Response = request.post_feed_request()
+        get_feed_data_or_exit(feed_response=response)
+    sys.exit(0)
+
+
+@click.command()
+def feed_all():
+    """ Feed all your pets.
+
+     This command will normal pets, then your quest pets, and finally all your
+     pets that were hatched with magic hatching potions.
+
+     This command will first show you the feeding plan, ask for
+     your confirmation, and then feed all the listed pets.
+    """
+    log.debug("hopla feed-all")
+    feed_all_pets_and_exit()

--- a/src/hopla/cli/feed_all.py
+++ b/src/hopla/cli/feed_all.py
@@ -64,13 +64,13 @@ def feed_all_pets_and_exit() -> NoReturn:
 
 @click.command()
 def feed_all():
-    """ Feed all your pets.
+    """Feed all your pets.
 
-     This command will normal pets, then your quest pets, and finally all your
-     pets that were hatched with magic hatching potions.
+    This command will first feed normal pets, then your quest pets, and
+    finally all your pets that were hatched with magic hatching potions.
 
-     This command will first show you the feeding plan, ask for
-     your confirmation, and then feed all the listed pets.
+    Not this command will first show you the feeding plan, and for safety,
+    ask for your confirmation. Pets will only if you confirm this prompt.
     """
     log.debug("hopla feed-all")
     feed_all_pets_and_exit()

--- a/src/hopla/cli/get_group.py
+++ b/src/hopla/cli/get_group.py
@@ -9,8 +9,8 @@ import click
 import requests
 
 from hopla.hoplalib.http import HabiticaRequest, UrlBuilder
-from hopla.hoplalib.outputformatter import JsonFormatter
 from hopla.hoplalib.requests_helper import get_data_or_exit
+from hopla.hoplalib.outputformatter import JsonFormatter
 
 log = logging.getLogger()
 

--- a/src/hopla/hoplalib/zoo/feeding_clickhelper.py
+++ b/src/hopla/hoplalib/zoo/feeding_clickhelper.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""
+A module with helper functions for the `hopla feed` and `hopla feed-all`
+CLI commands.
+"""
+import sys
+
+import click
+import requests
+
+from hopla.hoplalib.outputformatter import JsonFormatter
+
+
+def get_feed_data_or_exit(feed_response: requests.Response):
+    """
+    Given a feed response, if the API request was successful, return interesting
+    feeding information. On failure, exit with an error message.
+    """
+    response_json = feed_response.json()
+    if response_json["success"]:
+        feed_data = {
+            "feeding_status": response_json["data"],
+            "message": response_json["message"]
+        }
+
+        click.echo(JsonFormatter(feed_data).format_with_double_quotes())
+        return feed_data
+
+    click.echo(response_json["message"])
+    sys.exit(1)

--- a/src/hopla/hoplalib/zoo/foodmodels.py
+++ b/src/hopla/hoplalib/zoo/foodmodels.py
@@ -187,7 +187,7 @@ class FoodStockpileBuilder:
     def __repr__(self):
         return self.__class__.__name__ + f"({self.__stockpile})"
 
-    def user(self, habitica_user: HabiticaUser):
+    def user(self, habitica_user: HabiticaUser) -> "FoodStockpileBuilder":
         """
         Add a user's food to the stockpile. This ignores saddles,
         cakes, and other rare foods.

--- a/src/hopla/hoplalib/zoo/petdata.py
+++ b/src/hopla/hoplalib/zoo/petdata.py
@@ -281,19 +281,22 @@ class PetData:
     ]
     # Consider refactoring this entire class to contain more semantic information when important.
 
-    event_item_sequence_pet_names = [
+    event_sequence_pet_names = [
         "Wolf-Veteran", "Turkey-Base", "JackOLantern-Base", "Tiger-Veteran", "Turkey-Gilded",
         "Lion-Veteran", "Gryphon-RoyalPurple", "JackOLantern-Ghost", "Orca-Base", "Bear-Veteran",
         "Fox-Veteran", "JackOLantern-Glow", "JackOLantern-RoyalPurple"
     ]
+    """https://habitica.fandom.com/wiki/Event_Item_Sequences"""
 
     other_pet_names = [
         "Jackalope-RoyalPurple", "BearCub-Polar", "Dragon-Hydra", "Wolf-Cerberus",
         "Gryphon-Gryphatrice", "Aether-Invisible"
     ]
 
-    rare_pet_names = world_boss_reward_pet_names + event_item_sequence_pet_names + other_pet_names
-    """Rare pets: <https://habitica.fandom.com/wiki/Pets#Rare_Pets>"""
+    rare_pet_names = world_boss_reward_pet_names + event_sequence_pet_names + other_pet_names
+    """Rare pet names are pets that cannot be hatched.
+    @see: <https://habitica.fandom.com/wiki/Pets#Rare_Pets>
+    """
 
     only_1favorite_food_pet_names = generation1_pet_names + quest_pet_names
     """Only quest pets and gen1 pets have only 1 favorite food (anno Sept. 2021)"""

--- a/src/hopla/hoplalib/zoo/zoofeeding_algorithms.py
+++ b/src/hopla/hoplalib/zoo/zoofeeding_algorithms.py
@@ -1,7 +1,6 @@
 """
 A modules with algorithms for feeding multiple pets at once.
 """
-from collections import namedtuple
 from dataclasses import dataclass
 from typing import List
 from copy import deepcopy
@@ -9,8 +8,20 @@ from copy import deepcopy
 from hopla.hoplalib.zoo.foodmodels import FoodStockpile
 from hopla.hoplalib.zoo.petmodels import Pet, Zoo, ZooHelper
 
-FeedPlanItem = namedtuple(typename="FeedPlanItem",
-                          field_names=["pet_name", "food_name", "times"])
+
+@dataclass(frozen=True)
+class FeedPlanItem:
+    """An item of a zookeeper feed plan.
+
+    Every item on the zookeeper plan describes an action to feed 1 pet.
+    """
+    pet_name: str
+    food_name: str
+    times: int
+
+    def format_item(self) -> str:
+        """A to string function for nice terminal output"""
+        return f"Pet {self.pet_name} will get {self.times} {self.food_name}."
 
 
 @dataclass
@@ -49,6 +60,11 @@ class ZookeeperFeedPlan:
         no FeedPlanItems have been added yet.
         """
         return self.__feed_plan
+
+    def format_plan(self):
+        """A to string function for nice terminal output"""
+        joined_plan: str = "\n".join([item.format_item() for item in self.__feed_plan])
+        return f"{joined_plan}\n"
 
 
 @dataclass

--- a/src/hopla/hoplalib/zoo/zoofeeding_algorithms.py
+++ b/src/hopla/hoplalib/zoo/zoofeeding_algorithms.py
@@ -37,6 +37,14 @@ class ZookeeperFeedPlan:
     def __iter__(self):
         return iter(self.__feed_plan)
 
+    def __len__(self) -> int:
+        """Return the number of FeedPlanItems in this zookeeper feed plan."""
+        return len(self.__feed_plan)
+
+    def isempty(self):
+        """Return true if the feed plan is empty."""
+        return len(self) == 0
+
     def add_to_feed_plan(self, pet_name: str, food_name: str, times: int) -> None:
         """Add an item to the zookeeper's feed plan.
 
@@ -119,13 +127,13 @@ class ZooFeedingAlgorithm:
             pet: Pet = pair.pet
 
             if pet.has_just_1_favorite_food():
-                food_name = pet.favorite_food()
+                food_name: str = pet.favorite_food()
             else:
-                food_name = self.__stockpile.get_most_abundant_food()
+                food_name: str = self.__stockpile.get_most_abundant_food()
 
-            times = pet.required_food_items_until_mount(food_name)
+            times: int = pet.required_food_items_until_mount(food_name)
             if self.__stockpile.has_sufficient(food_name, n=times):
-                subtract_times = -times
+                subtract_times: int = -times
                 self.__stockpile.add_food(food_name,
                                           n=subtract_times)
                 self.__zookeeper_plan.add_to_feed_plan(

--- a/src/tests/cli/test_feed.py
+++ b/src/tests/cli/test_feed.py
@@ -3,8 +3,7 @@ from requests.status_codes import codes
 from click.testing import CliRunner, Result
 from unittest.mock import patch, MagicMock
 
-from hopla.cli.feed import feed, feed_all, \
-    get_feed_times_until_mount
+from hopla.cli.feed import feed, get_feed_times_until_mount
 from hopla.cli.groupcmds.get_user import HabiticaUser
 
 
@@ -250,22 +249,3 @@ class TestFeedCliCommand:
         assert response_msg in result.stdout
         assert f'"feeding_status": {response_data}' in result.stdout
 
-    @patch("hopla.cli.feed.HabiticaUserRequest.request_user_data_or_exit")
-    def test_feed_all_pets_user_aborts(self,
-                                       mock_user_request: MagicMock,
-                                       simple_user: HabiticaUser):
-        mock_user_request.return_value = simple_user
-        runner = CliRunner()
-        result: Result = runner.invoke(feed_all, input="No")
-
-        assert "Aborted. No pets were fed." in result.stdout
-        # aborting should not be an error
-        assert result.exit_code == 0
-
-    @pytest.fixture
-    def simple_user(self) -> HabiticaUser:
-        return HabiticaUser({"items": {
-            "pets": {},
-            "mounts": {},
-            "food": {}
-        }})

--- a/src/tests/cli/test_feed.py
+++ b/src/tests/cli/test_feed.py
@@ -3,7 +3,8 @@ from requests.status_codes import codes
 from click.testing import CliRunner, Result
 from unittest.mock import patch, MagicMock
 
-from hopla.cli.feed import feed, get_feed_times_until_mount
+from hopla.cli.feed import feed, feed_all, \
+    get_feed_times_until_mount
 from hopla.cli.groupcmds.get_user import HabiticaUser
 
 
@@ -135,7 +136,7 @@ class TestFeedCliCommand:
         mock_feed_api_call.assert_called_with()  # no args
 
         # TODO: https://github.com/melvio/hopla/issues/104
-        assert result.exit_code == codes.unauthorized
+        assert result.exit_code == 1
         assert result.stdout == f"{expected_errmsg}\n"
 
     def test_cannot_specify_times_and_until_mount(self):
@@ -248,3 +249,23 @@ class TestFeedCliCommand:
         assert result.exit_code == 0
         assert response_msg in result.stdout
         assert f'"feeding_status": {response_data}' in result.stdout
+
+    @patch("hopla.cli.feed.HabiticaUserRequest.request_user_data_or_exit")
+    def test_feed_all_pets_user_aborts(self,
+                                       mock_user_request: MagicMock,
+                                       simple_user: HabiticaUser):
+        mock_user_request.return_value = simple_user
+        runner = CliRunner()
+        result: Result = runner.invoke(feed_all, input="No")
+
+        assert "Aborted. No pets were fed." in result.stdout
+        # aborting should not be an error
+        assert result.exit_code == 0
+
+    @pytest.fixture
+    def simple_user(self) -> HabiticaUser:
+        return HabiticaUser({"items": {
+            "pets": {},
+            "mounts": {},
+            "food": {}
+        }})

--- a/src/tests/cli/test_feed.py
+++ b/src/tests/cli/test_feed.py
@@ -137,7 +137,6 @@ class TestFeedCliCommand:
 
         mock_feed_api_call.assert_called_with()  # no args
 
-        # TODO: https://github.com/melvio/hopla/issues/104
         assert result.exit_code == 1
         assert result.stdout == f"{expected_errmsg}\n"
 

--- a/src/tests/cli/test_feed_all.py
+++ b/src/tests/cli/test_feed_all.py
@@ -68,12 +68,14 @@ class TestFeedAllCliCommand:
         assert result.exit_code == 0
         assert result.stdout.startswith("The feed plan is empty.")
 
+    @pytest.mark.parametrize("yes_response", ["y", "Y", "yes", "Yes", "YES"])
     @patch("hopla.cli.feed_all.FeedPostRequester.post_feed_request")
     @patch("hopla.cli.feed_all.HabiticaUserRequest.request_user_data_or_exit")
     def test_feed_all_ok(self,
                          mock_user_request: MagicMock,
                          mock_feed_request: MagicMock,
-                         user_with_feedable_pet: HabiticaUser):
+                         user_with_feedable_pet: HabiticaUser,
+                         yes_response: str):
         # This user has a pet that can be grown into a mount by feeding 8 Fish
         mock_user_request.return_value = user_with_feedable_pet
 
@@ -81,10 +83,10 @@ class TestFeedAllCliCommand:
         mock_feed_request.return_value = MockOkResponse(msg=feed_msg)
 
         runner = CliRunner()
-        result: Result = runner.invoke(feed_all, input="Yes")
+        result: Result = runner.invoke(feed_all, input=yes_response)
 
         assert "Pet Velociraptor-Skeleton will get 8 Fish.\n" in result.stdout
-        assert "Do you want to proceed? [y/N]: Yes\n" in result.stdout
+        assert f"Do you want to proceed? [y/N]: {yes_response}\n" in result.stdout
         assert feed_msg in result.stdout
         assert '"feeding_status": -1' in result.stdout
         assert result.exit_code == 0

--- a/src/tests/cli/test_feed_all.py
+++ b/src/tests/cli/test_feed_all.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+import pytest
+from click.testing import CliRunner, Result
+from unittest.mock import patch, MagicMock
+from requests.status_codes import codes
+
+from hopla.cli.feed_all import feed_all
+from hopla.cli.groupcmds.get_user import HabiticaUser
+
+
+class MockBadGatewayResponse:
+    def __init__(self, msg):
+        self.status_code = codes.bad_gateway
+        self.__json = {"success": False, "error": "BadGateway", "message": msg}
+
+    def json(self):
+        return self.__json
+
+
+class MockOkResponse:
+    def __init__(self, msg: str):
+        self.status_code = codes.ok
+        self.__json = {"success": True, "data": -1, "message": msg}
+
+    def json(self):
+        return self.__json
+
+
+class TestFeedAllCliCommand:
+
+    @pytest.mark.parametrize(
+        "no_response", [
+            "n", "N", "no", "No", "NO", "", "anything else"
+        ]
+    )
+    @patch("hopla.cli.feed_all.HabiticaUserRequest.request_user_data_or_exit")
+    def test_feed_all_pets_user_aborts(self,
+                                       mock_user_request: MagicMock,
+                                       no_response: str,
+                                       user_with_feedable_pet: HabiticaUser):
+        mock_user_request.return_value = user_with_feedable_pet
+        runner = CliRunner()
+        result: Result = runner.invoke(feed_all, input=no_response)
+
+        assert "Aborted!" in result.stdout
+        assert result.exit_code == 1
+
+    @patch("hopla.cli.feed_all.HabiticaUserRequest.request_user")
+    def test_feed_all_api_bad_gateway_fail(self, mock_user_request: MagicMock):
+        bad_gateway_msg = "Service responded with a status of 502 (Bad Gateway)"
+        mock_user_request.return_value = MockBadGatewayResponse(msg=bad_gateway_msg)
+
+        runner = CliRunner()
+        result: Result = runner.invoke(feed_all, input="Yes")
+
+        assert result.exit_code == 1
+        assert bad_gateway_msg in result.stdout
+
+    @patch("hopla.cli.feed_all.HabiticaUserRequest.request_user_data_or_exit")
+    def test_feed_all_empty_plan_ok(self,
+                                    mock_user_request: MagicMock,
+                                    user_with_no_feedable_pets: HabiticaUser):
+        mock_user_request.return_value = user_with_no_feedable_pets
+
+        runner = CliRunner()
+        result: Result = runner.invoke(feed_all, input="Yes")
+
+        assert result.exit_code == 0
+        assert result.stdout.startswith("The feed plan is empty.")
+
+    @patch("hopla.cli.feed_all.FeedPostRequester.post_feed_request")
+    @patch("hopla.cli.feed_all.HabiticaUserRequest.request_user_data_or_exit")
+    def test_feed_all_ok(self,
+                         mock_user_request: MagicMock,
+                         mock_feed_request: MagicMock,
+                         user_with_feedable_pet: HabiticaUser):
+        # This user has a pet that can be grown into a mount by feeding 8 Fish
+        mock_user_request.return_value = user_with_feedable_pet
+
+        feed_msg = "You have tamed Skeleton Velociraptor, let's go for a ride!"
+        mock_feed_request.return_value = MockOkResponse(msg=feed_msg)
+
+        runner = CliRunner()
+        result: Result = runner.invoke(feed_all, input="Yes")
+
+        assert "Pet Velociraptor-Skeleton will get 8 Fish.\n" in result.stdout
+        assert "Do you want to proceed? [y/N]: Yes\n" in result.stdout
+        assert feed_msg in result.stdout
+        assert '"feeding_status": -1' in result.stdout
+        assert result.exit_code == 0
+
+    @pytest.fixture
+    def user_with_feedable_pet(self) -> HabiticaUser:
+        return HabiticaUser({"items": {
+            "pets": {"Velociraptor-Skeleton": 10},
+            "mounts": {},
+            "food": {"Fish": 20}
+        }})
+
+    @pytest.fixture
+    def user_with_no_feedable_pets(self) -> HabiticaUser:
+        return HabiticaUser({"items": {
+            "pets": {},
+            "mounts": {},
+            "food": {"Fish": 20}
+        }})

--- a/src/tests/hoplalib/zoo/test_petcontroller.py
+++ b/src/tests/hoplalib/zoo/test_petcontroller.py
@@ -28,19 +28,13 @@ class TestFeedPostRequester:
         expected_url = f"https://habitica.com/api/v3/user/feed/{pet}/{food}"
         assert result_url == expected_url
 
-    @pytest.mark.parametrize(
-        "times,expected_times",
-        [(2, 2), (None, 1)]
-    )
+    @pytest.mark.parametrize("times,expected_times", [(2, 2), (None, 1)])
     @patch("hopla.hoplalib.zoo.petcontroller.HabiticaRequest.default_headers")
     @patch("hopla.hoplalib.zoo.petcontroller.requests.post")
     def test_post_feed_request(self, mock_post_request: MagicMock,
                                mock_headers: MagicMock,
                                times: int,
                                expected_times: int):
-        # No need for credentials, were mocking the API call
-        mock_post_request.return_value = MagicMock()
-
         pet_name = "Egg-CottonCandyPink"
         food_name = "CottonCandyPink"
 

--- a/src/tests/hoplalib/zoo/test_petcontroller.py
+++ b/src/tests/hoplalib/zoo/test_petcontroller.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+from unittest.mock import MagicMock, patch
+
+import pytest
+
 from hopla.hoplalib.zoo.petcontroller import FeedPostRequester
 
 
@@ -23,3 +27,32 @@ class TestFeedPostRequester:
 
         expected_url = f"https://habitica.com/api/v3/user/feed/{pet}/{food}"
         assert result_url == expected_url
+
+    @pytest.mark.parametrize(
+        "times,expected_times",
+        [(2, 2), (None, 1)]
+    )
+    @patch("hopla.hoplalib.zoo.petcontroller.HabiticaRequest.default_headers")
+    @patch("hopla.hoplalib.zoo.petcontroller.requests.post")
+    def test_post_feed_request(self, mock_post_request: MagicMock,
+                               mock_headers: MagicMock,
+                               times: int,
+                               expected_times: int):
+        # No need for credentials, were mocking the API call
+        mock_post_request.return_value = MagicMock()
+
+        pet_name = "Egg-CottonCandyPink"
+        food_name = "CottonCandyPink"
+
+        feed_requester = FeedPostRequester(
+            pet_name=pet_name, food_name=food_name, food_amount=times
+        )
+
+        _ = feed_requester.post_feed_request()
+
+        expected_url = f"https://habitica.com/api/v3/user/feed/{pet_name}/{food_name}"
+        mock_post_request.assert_called_with(
+            url=expected_url,
+            headers=mock_headers,
+            params={"amount": expected_times}
+        )

--- a/src/tests/hoplalib/zoo/test_petdata.py
+++ b/src/tests/hoplalib/zoo/test_petdata.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+import random
+
+import pytest
+
+from hopla.hoplalib.zoo.petdata import PetData
+
+_SAMPLE_SIZE_LARGE = 20
+_SAMPLE_SIZE_SMALL = 5
+
+
+class TestPetData:
+
+    @pytest.mark.parametrize(
+        "gen1pet,magic_pet,quest_pet", list(zip(
+            random.sample(PetData.generation1_pet_names, k=_SAMPLE_SIZE_LARGE),
+            random.sample(PetData.magic_potion_pet_names, k=_SAMPLE_SIZE_LARGE),
+            random.sample(PetData.quest_pet_names, k=_SAMPLE_SIZE_LARGE)
+        ))
+    )
+    def test_correct_grouping_of_feedable_pets(self, gen1pet: str,
+                                               magic_pet: str,
+                                               quest_pet: str):
+        assert gen1pet not in PetData.magic_potion_pet_names
+        assert gen1pet not in PetData.quest_pet_names
+        assert magic_pet not in PetData.generation1_pet_names
+        assert magic_pet not in PetData.quest_pet_names
+        assert quest_pet not in PetData.generation1_pet_names
+        assert quest_pet not in PetData.magic_potion_pet_names
+
+        assert gen1pet in PetData.feedable_pet_names
+        assert magic_pet in PetData.feedable_pet_names
+        assert quest_pet in PetData.feedable_pet_names
+
+        assert gen1pet in PetData.only_1favorite_food_pet_names
+        assert magic_pet not in PetData.only_1favorite_food_pet_names
+        assert quest_pet in PetData.only_1favorite_food_pet_names
+
+        assert gen1pet not in PetData.unfeedable_pet_names
+        assert magic_pet not in PetData.unfeedable_pet_names
+        assert quest_pet not in PetData.unfeedable_pet_names
+
+        assert gen1pet in PetData.pet_names
+        assert magic_pet in PetData.pet_names
+        assert quest_pet in PetData.pet_names
+
+    @pytest.mark.parametrize(
+        "wacky_pet,world_boss_pet,event_sequence_pet,other_pet", list(zip(
+            random.sample(PetData.wacky_pet_names, k=_SAMPLE_SIZE_SMALL),
+            random.sample(PetData.world_boss_reward_pet_names, k=_SAMPLE_SIZE_SMALL),
+            random.sample(PetData.event_sequence_pet_names, k=_SAMPLE_SIZE_SMALL),
+            random.sample(PetData.other_pet_names, k=_SAMPLE_SIZE_SMALL),
+        ))
+    )
+    def test_correct_grouping_rare_pets(self,
+                                        wacky_pet: str,
+                                        world_boss_pet: str,
+                                        event_sequence_pet: str,
+                                        other_pet: str):
+        assert wacky_pet not in PetData.world_boss_reward_pet_names
+        assert wacky_pet not in PetData.event_sequence_pet_names
+        assert wacky_pet not in PetData.other_pet_names
+
+        assert world_boss_pet not in PetData.wacky_pet_names
+        assert world_boss_pet not in PetData.event_sequence_pet_names
+        assert world_boss_pet not in PetData.other_pet_names
+
+        assert event_sequence_pet not in PetData.wacky_pet_names
+        assert event_sequence_pet not in PetData.world_boss_reward_pet_names
+        assert event_sequence_pet not in PetData.other_pet_names
+
+        assert other_pet not in PetData.wacky_pet_names
+        assert other_pet not in PetData.event_sequence_pet_names
+        assert other_pet not in PetData.world_boss_reward_pet_names
+
+        assert wacky_pet in PetData.unfeedable_pet_names
+        assert world_boss_pet in PetData.unfeedable_pet_names
+        assert event_sequence_pet in PetData.unfeedable_pet_names
+        assert other_pet in PetData.unfeedable_pet_names
+
+        assert wacky_pet not in PetData.only_1favorite_food_pet_names
+        assert world_boss_pet not in PetData.only_1favorite_food_pet_names
+        assert event_sequence_pet not in PetData.only_1favorite_food_pet_names
+        assert other_pet not in PetData.only_1favorite_food_pet_names
+
+        assert wacky_pet not in PetData.feedable_pet_names
+        assert world_boss_pet not in PetData.feedable_pet_names
+        assert event_sequence_pet not in PetData.feedable_pet_names
+        assert other_pet not in PetData.feedable_pet_names
+
+
+        assert wacky_pet not in PetData.rare_pet_names
+        assert world_boss_pet in PetData.rare_pet_names
+        assert event_sequence_pet in PetData.rare_pet_names
+        assert other_pet in PetData.rare_pet_names

--- a/src/tests/hoplalib/zoo/test_petmodels.py
+++ b/src/tests/hoplalib/zoo/test_petmodels.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 import random
-from typing import Optional
 
 import pytest
 


### PR DESCRIPTION
- Implemented --feed-pets-until-out-of-food
- Refactor the feed parameter checker
- Change return codes to 1 on failure
- Split of feed-all from feed cmd
- Split off feed-all command
- Add unit test for failing API gateway
- Add coverage for co-related functionality
