### PR TITLE
codequality/181 shorten verbose names

### DIFF
--- a/src/hopla/cli/feed.py
+++ b/src/hopla/cli/feed.py
@@ -11,7 +11,7 @@ import requests
 
 from hopla.cli.groupcmds.get_user import HabiticaUser, HabiticaUserRequest
 from hopla.hoplalib.errors import YouFoundABugRewardError
-from hopla.hoplalib.zoo.feeding_clickhelper import get_feed_data_or_exit
+from hopla.hoplalib.zoo.feed_clickhelper import get_feed_data_or_exit
 from hopla.hoplalib.zoo.fooddata import FoodData
 from hopla.hoplalib.zoo.foodmodels import FoodStockpile, FoodStockpileBuilder
 from hopla.hoplalib.zoo.petcontroller import FeedPostRequester
@@ -55,7 +55,7 @@ def get_feed_times_until_mount(pet_name: str, food_name: str) -> Union[int, NoRe
     pet: Pet = pair.pet
     if pair.can_feed_pet() is False:
         sys.exit(f"Can't feed pet {pet_name}. "
-                 + pet.feeding_status_explanation())
+                 + pet.feed_status_explanation())
 
     return pet.required_food_items_until_mount(food_name)
 

--- a/src/hopla/cli/feed_all.py
+++ b/src/hopla/cli/feed_all.py
@@ -13,25 +13,25 @@ from hopla.hoplalib.throttling import ApiRequestThrottler
 from hopla.hoplalib.zoo.foodmodels import FoodStockpile, FoodStockpileBuilder
 from hopla.hoplalib.zoo.petcontroller import FeedPostRequester
 from hopla.hoplalib.zoo.zoomodels import Zoo, ZooBuilder
-from hopla.hoplalib.zoo.zoofeeding_algorithms import ZooFeedingAlgorithm, ZookeeperFeedPlan
+from hopla.hoplalib.zoo.zoofeed_algorithms import ZooFeedAlgorithm, ZookeeperFeedPlan
 
 log = logging.getLogger()
 
 
-def __get_feeding_plan_or_exit() -> Union[NoReturn, ZookeeperFeedPlan]:
+def __get_feed_plan_or_exit() -> Union[NoReturn, ZookeeperFeedPlan]:
     """Get the user and build the zookeeper plan"""
     user: HabiticaUser = HabiticaUserRequest().request_user_data_or_exit()
     stockpile: FoodStockpile = FoodStockpileBuilder().user(user).build()
     zoo: Zoo = ZooBuilder(user).build()
 
-    algorithm = ZooFeedingAlgorithm(zoo=zoo, stockpile=stockpile)
+    algorithm = ZooFeedAlgorithm(zoo=zoo, stockpile=stockpile)
     return algorithm.make_plan()
 
 
 def __confirm_with_user_or_abort(plan: ZookeeperFeedPlan) -> Optional[NoReturn]:
     """Ask the user to confirm the specified plan.
 
-    :param plan: the zookeeper feeding plan to display
+    :param plan: the zookeeper feed plan to display
     :return: Don't return if the user wants to abort
     """
 
@@ -41,7 +41,7 @@ def __confirm_with_user_or_abort(plan: ZookeeperFeedPlan) -> Optional[NoReturn]:
 
 def feed_all_pets_and_exit() -> NoReturn:
     """Feed all the pets"""
-    plan: ZookeeperFeedPlan = __get_feeding_plan_or_exit()
+    plan: ZookeeperFeedPlan = __get_feed_plan_or_exit()
     if plan.isempty():
         click.echo(
             "The feed plan is empty. Reasons could include:\n"
@@ -69,7 +69,7 @@ def feed_all():
     This command will first feed normal pets, then your quest pets, and
     finally all your pets that were hatched with magic hatching potions.
 
-    Not this command will first show you the feeding plan, and for safety,
+    Not this command will first show you the feed plan, and for safety,
     ask for your confirmation. Pets will only if you confirm this prompt.
     """
     log.debug("hopla feed-all")

--- a/src/hopla/cli/groupcmds/hatch.py
+++ b/src/hopla/cli/groupcmds/hatch.py
@@ -24,7 +24,7 @@ def hatch_egg(*, egg_name: str, potion_name: str) -> NoReturn:
     """
     requester = HatchRequester(
         egg_name=egg_name,
-        hatching_potion_name=potion_name
+        hatch_potion_name=potion_name
     )
     response: requests.Response = requester.post_hatch_egg_request()
     json: dict = response.json()

--- a/src/hopla/cli/hatch/quest_egg.py
+++ b/src/hopla/cli/hatch/quest_egg.py
@@ -7,7 +7,7 @@ import logging
 import click
 
 from hopla.cli.groupcmds.hatch import hatch_egg
-from hopla.hoplalib.hatchery.hatchdata import EggData, HatchingPotionData
+from hopla.hoplalib.hatchery.hatchdata import EggData, HatchPotionData
 
 log = logging.getLogger()
 
@@ -19,7 +19,7 @@ log = logging.getLogger()
 )
 @click.argument(
     "potion_name",
-    type=click.Choice(HatchingPotionData.drop_hatching_potion_names)
+    type=click.Choice(HatchPotionData.drop_hatch_potion_names)
 )
 def quest_egg(egg_name: str, potion_name: str):
     """hatch a quest egg.

--- a/src/hopla/cli/hatch/standard_egg.py
+++ b/src/hopla/cli/hatch/standard_egg.py
@@ -8,7 +8,7 @@ from typing import NoReturn
 import click
 
 from hopla.cli.groupcmds.hatch import hatch_egg
-from hopla.hoplalib.hatchery.hatchdata import EggData, HatchingPotionData
+from hopla.hoplalib.hatchery.hatchdata import EggData, HatchPotionData
 
 log = logging.getLogger()
 
@@ -20,7 +20,7 @@ log = logging.getLogger()
 )
 @click.argument(
     "potion_name", metavar="POTION_NAME",
-    type=click.Choice(sorted(HatchingPotionData.hatching_potion_names))
+    type=click.Choice(sorted(HatchPotionData.hatch_potion_names))
 )
 def standard_egg(egg_name: str, potion_name: str) -> NoReturn:
     """Hatch a standard egg.

--- a/src/hopla/cli/hatch_all.py
+++ b/src/hopla/cli/hatch_all.py
@@ -77,5 +77,5 @@ def _hatch_eggs(plan: HatchPlan) -> None:
 def to_pet_list(pets: Dict[str, int]) -> List[Pet]:
     """Helper method that takes a pet_dict and returns a List[Pet]."""
     return [
-        Pet(name, feeding_status=FeedStatus(n)) for (name, n) in pets.items()
+        Pet(name, feed_status=FeedStatus(n)) for (name, n) in pets.items()
     ]

--- a/src/hopla/cli/hatch_all.py
+++ b/src/hopla/cli/hatch_all.py
@@ -10,7 +10,7 @@ import click
 from hopla.hoplalib.hatchery.eggmodels import EggCollection
 from hopla.hoplalib.hatchery.hatchalgorithms import HatchPlan, HatchPlanMaker
 from hopla.hoplalib.hatchery.hatchcontroller import HatchRequester
-from hopla.hoplalib.hatchery.hatchpotionmodels import HatchingPotionCollection
+from hopla.hoplalib.hatchery.hatchpotionmodels import HatchPotionCollection
 from hopla.hoplalib.throttling import ApiRequestThrottler
 from hopla.hoplalib.user.usercontroller import HabiticaUserRequest
 from hopla.hoplalib.user.usermodels import HabiticaUser
@@ -23,9 +23,9 @@ def hatch_all():
     """Hatch all the available eggs.
 
     \b
-    hopla hatch-all - Print all possible egg-hatchings that are possible, and,
-                      if the user confirms, hatches the available eggs
-                      with the available hatching potions.
+    hopla hatch-all - Print the possible hatchings, and, if the user
+                      confirms, hatch all the available eggs
+                      with all the available hatching potions.
 
     \b
     Examples:
@@ -40,13 +40,13 @@ def hatch_all():
     """
     user: HabiticaUser = HabiticaUserRequest().request_user_data_or_exit()
     eggs = EggCollection(user.get_eggs())
-    potions = HatchingPotionCollection(user.get_hatching_potions())
+    potions = HatchPotionCollection(user.get_hatch_potions())
     pets: List[Pet] = to_pet_list(user.get_pets())
 
     plan_maker = HatchPlanMaker(egg_collection=eggs, hatch_potion_collection=potions)
     plan: HatchPlan = plan_maker \
         .make_plan() \
-        .remove_hatching_if_pet_available(pets)
+        .remove_hatch_item_if_pet_available(pets)
 
     if plan.is_empty():
         click.echo("The hatch plan is empty. Do you have enough pets and hatching potions?")

--- a/src/hopla/cli/hatch_all.py
+++ b/src/hopla/cli/hatch_all.py
@@ -14,7 +14,7 @@ from hopla.hoplalib.hatchery.hatchpotionmodels import HatchingPotionCollection
 from hopla.hoplalib.throttling import ApiRequestThrottler
 from hopla.hoplalib.user.usercontroller import HabiticaUserRequest
 from hopla.hoplalib.user.usermodels import HabiticaUser
-from hopla.hoplalib.zoo.foodmodels import FeedingStatus
+from hopla.hoplalib.zoo.foodmodels import FeedStatus
 from hopla.hoplalib.zoo.petmodels import Pet
 
 
@@ -77,5 +77,5 @@ def _hatch_eggs(plan: HatchPlan) -> None:
 def to_pet_list(pets: Dict[str, int]) -> List[Pet]:
     """Helper method that takes a pet_dict and returns a List[Pet]."""
     return [
-        Pet(name, feeding_status=FeedingStatus(n)) for (name, n) in pets.items()
+        Pet(name, feeding_status=FeedStatus(n)) for (name, n) in pets.items()
     ]

--- a/src/hopla/hoplalib/hatchery/eggmodels.py
+++ b/src/hopla/hoplalib/hatchery/eggmodels.py
@@ -7,7 +7,7 @@ from typing import Dict
 
 from hopla.hoplalib.errors import YouFoundABugRewardError
 from hopla.hoplalib.hatchery.hatchdata import EggData
-from hopla.hoplalib.hatchery.hatchpotionmodels import HatchingPotion
+from hopla.hoplalib.hatchery.hatchpotionmodels import HatchPotion
 
 
 class EggException(YouFoundABugRewardError):
@@ -38,12 +38,12 @@ class Egg:
         """Return True if this is a quest egg. Else False"""
         return self.name in EggData.quest_egg_names
 
-    def can_be_hatched_by(self, potion: HatchingPotion) -> bool:
+    def can_be_hatched_by(self, potion: HatchPotion) -> bool:
         """Return true if the specified potion can hatch this egg."""
         if potion.quantity == 0 or self.quantity == 0:
             return False
         if self.is_quest_egg():
-            return potion.is_standard_hatching_potion()
+            return potion.is_standard_hatch_potion()
         return True
 
 

--- a/src/hopla/hoplalib/hatchery/hatchalgorithms.py
+++ b/src/hopla/hoplalib/hatchery/hatchalgorithms.py
@@ -86,8 +86,7 @@ class HatchPlan:
         :param pets: list of pets to check for clashes with the hatching
         :return: self for chaining
         """
-        pet_names: List[str] = [pet.pet_name for pet in pets
-                                if pet.is_available()]
+        pet_names: List[str] = [pet.name for pet in pets if pet.is_available()]
 
         self.plan = [hatch_item for hatch_item in self.plan
                      if hatch_item.result_pet_name() not in pet_names]

--- a/src/hopla/hoplalib/hatchery/hatchalgorithms.py
+++ b/src/hopla/hoplalib/hatchery/hatchalgorithms.py
@@ -6,8 +6,8 @@ from dataclasses import dataclass
 from typing import Any, List
 
 from hopla.hoplalib.hatchery.eggmodels import Egg, EggCollection
-from hopla.hoplalib.hatchery.hatchpotionmodels import HatchingPotion, \
-    HatchingPotionCollection
+from hopla.hoplalib.hatchery.hatchpotionmodels import HatchPotion, \
+    HatchPotionCollection
 from hopla.hoplalib.zoo.petmodels import Pet
 
 
@@ -15,7 +15,7 @@ from hopla.hoplalib.zoo.petmodels import Pet
 class HatchPlanItem:
     """Plan to hatch a specific egg with a specified potion."""
     egg: Egg
-    potion: HatchingPotion
+    potion: HatchPotion
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, HatchPlanItem) is False:
@@ -69,7 +69,7 @@ class HatchPlan:
         """Terminal-printable representation of this HatchPlan."""
         return "".join([item.format_item() for item in self.plan])
 
-    def add(self, *, egg: Egg, potion: HatchingPotion) -> "HatchPlan":
+    def add(self, *, egg: Egg, potion: HatchPotion) -> "HatchPlan":
         """Make the plan to hatch the egg with the specified potion.
 
         :param egg:
@@ -80,7 +80,7 @@ class HatchPlan:
         self.plan.append(hatch_plan_item)
         return self
 
-    def remove_hatching_if_pet_available(self, pets: List[Pet]) -> "HatchPlan":
+    def remove_hatch_item_if_pet_available(self, pets: List[Pet]) -> "HatchPlan":
         """Remove the hatching plan items for pets that are available.
 
         :param pets: list of pets to check for clashes with the hatching
@@ -104,7 +104,7 @@ class HatchPlanMaker:
 
     def __init__(self, *,
                  egg_collection: EggCollection,
-                 hatch_potion_collection: HatchingPotionCollection):
+                 hatch_potion_collection: HatchPotionCollection):
         self.__eggs = egg_collection
         self.__potions = hatch_potion_collection
         self.__hatch_plan = HatchPlan()
@@ -123,10 +123,10 @@ class HatchPlanMaker:
         for egg_name in self.__eggs:
             egg: Egg = self.__eggs[egg_name]
             for potion_name in self.__potions:
-                potion: HatchingPotion = self.__potions[potion_name]
+                potion: HatchPotion = self.__potions[potion_name]
                 if egg.can_be_hatched_by(potion):
                     self.__hatch_plan.add(egg=egg, potion=potion)
                     self.__eggs.remove_egg(egg)
-                    self.__potions.remove_hatching_potion(potion)
+                    self.__potions.remove_hatch_potion(potion)
 
         return self.__hatch_plan

--- a/src/hopla/hoplalib/hatchery/hatchcontroller.py
+++ b/src/hopla/hoplalib/hatchery/hatchcontroller.py
@@ -16,12 +16,12 @@ class HatchRequester(HabiticaRequest):
     [APIDOCS](https://habitica.com/apidoc/#api-User-UserHatch)
     """
     egg_name: str
-    hatching_potion_name: str
+    hatch_potion_name: str
 
     @property
     def url(self) -> str:
-        """Hatch endpoint with egg and hatching_potion as path params."""
-        path_extension = f"/user/hatch/{self.egg_name}/{self.hatching_potion_name}"
+        """Hatch endpoint with egg and hatch_potion_name as path params."""
+        path_extension = f"/user/hatch/{self.egg_name}/{self.hatch_potion_name}"
         return UrlBuilder(path_extension=path_extension).url
 
     def post_hatch_egg_request(self) -> requests.Response:
@@ -35,5 +35,5 @@ class HatchRequester(HabiticaRequest):
         response: requests.Response = self.post_hatch_egg_request()
         response_json: Dict[str, Any] = response.json()
         if response_json["success"] is True:
-            return f"Successfully hatched a {self.egg_name}-{self.hatching_potion_name}."
+            return f"Successfully hatched a {self.egg_name}-{self.hatch_potion_name}."
         return f"{response_json['error']}: {response_json['message']}"

--- a/src/hopla/hoplalib/hatchery/hatchdata.py
+++ b/src/hopla/hoplalib/hatchery/hatchdata.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Module with hatching data (i.e. eggs and hatching potions data)
+Module with egg and hatch potion data.
 """
 from typing import List
 
@@ -35,9 +35,9 @@ class EggData:
     """All eggs in habitica."""
 
 
-class HatchingPotionData:
+class HatchPotionData:
     """Class with data about hatching potions."""
-    drop_hatching_potion_names = [
+    drop_hatch_potion_names = [
         "Base", "CottonCandyBlue", "CottonCandyPink", "Desert", "Golden",
         "Red", "Shade", "Skeleton", "White", "Zombie"
     ]
@@ -46,7 +46,7 @@ class HatchingPotionData:
     hopla api content | jq.dropHatchingPotions | jq keys
     """
 
-    magic_hatching_potion_names = [
+    magic_hatch_potion_names = [
         "Amber", "Aquatic", "Aurora", "AutumnLeaf", "BirchBark", "BlackPearl",
         "Bronze", "Celestial", "Cupid", "Ember", "Fairy", "Floral",
         "Fluorite", "Frost", "Ghost", "Glass", "Glow", "Holly", "IcySnow",
@@ -61,17 +61,14 @@ class HatchingPotionData:
     hopla api content | jq .premiumHatchingPotions | jq keys
     """
 
-    wacky_hatching_potion_names = ["Dessert", "Veggie"]
+    wacky_hatch_potion_names = ["Dessert", "Veggie"]
     """Wacky hatching potions. This list was retrieved by using:
            hopla api content | jq '.wackyHatchingPotions|keys'
     """
-    non_drop_hatching_potion_names: List[str] = (
-            magic_hatching_potion_names
-            + wacky_hatching_potion_names
+    non_drop_hatch_potion_names: List[str] = (
+            magic_hatch_potion_names
+            + wacky_hatch_potion_names
     )
 
-    hatching_potion_names: List[str] = (
-            drop_hatching_potion_names
-            + non_drop_hatching_potion_names
-    )
+    hatch_potion_names: List[str] = drop_hatch_potion_names + non_drop_hatch_potion_names
     """All potion names in habitica."""

--- a/src/hopla/hoplalib/hatchery/hatchpotionmodels.py
+++ b/src/hopla/hoplalib/hatchery/hatchpotionmodels.py
@@ -6,22 +6,22 @@ from dataclasses import dataclass
 from typing import Dict
 
 from hopla.hoplalib.errors import YouFoundABugRewardError
-from hopla.hoplalib.hatchery.hatchdata import HatchingPotionData
+from hopla.hoplalib.hatchery.hatchdata import HatchPotionData
 
 
-class HatchingPotionException(YouFoundABugRewardError):
+class HatchPotionException(YouFoundABugRewardError):
     """Exception raised when there is an error with an hatching potion."""
 
 
 @dataclass
-class HatchingPotion:
+class HatchPotion:
     """A habitica hatching potion."""
 
     def __init__(self, name: str, *, quantity: int = 1):
-        if name not in HatchingPotionData.hatching_potion_names:
-            raise HatchingPotionException(f"{name} is not a valid hatching potion name.")
+        if name not in HatchPotionData.hatch_potion_names:
+            raise HatchPotionException(f"{name} is not a valid hatching potion name.")
         if quantity < 0:
-            raise HatchingPotionException(f"{quantity} is below 0.")
+            raise HatchPotionException(f"{quantity} is below 0.")
 
         self.name = name
         self.quantity = quantity
@@ -29,28 +29,28 @@ class HatchingPotion:
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.name}: {self.quantity})"
 
-    def is_standard_hatching_potion(self) -> bool:
+    def is_standard_hatch_potion(self) -> bool:
         """Return true if this is a standard hatching potion."""
-        return self.name in HatchingPotionData.drop_hatching_potion_names
+        return self.name in HatchPotionData.drop_hatch_potion_names
 
-    def is_magic_hatching_potion(self) -> bool:
+    def is_magic_hatch_potion(self) -> bool:
         """Return true if this is a magic hatching potion."""
-        return self.name in HatchingPotionData.magic_hatching_potion_names
+        return self.name in HatchPotionData.magic_hatch_potion_names
 
-    def is_wacky_hatching_potion(self) -> bool:
+    def is_wacky_hatch_potion(self) -> bool:
         """Return true if this is a wacky hatching potion."""
-        return self.name in HatchingPotionData.wacky_hatching_potion_names
+        return self.name in HatchPotionData.wacky_hatch_potion_names
 
 
 @dataclass
-class HatchingPotionCollection:
+class HatchPotionCollection:
     """A collection of hatching potions, backed by a Dict[str, Egg]."""
 
     def __init__(self, potions: Dict[str, int] = None):
         if potions is None:
             potions = {}
-        self.__potions: Dict[str, HatchingPotion] = {
-            name: HatchingPotion(name, quantity=quantity) for (name, quantity) in potions.items()
+        self.__potions: Dict[str, HatchPotion] = {
+            name: HatchPotion(name, quantity=quantity) for (name, quantity) in potions.items()
         }
 
     def __len__(self) -> int:
@@ -59,24 +59,24 @@ class HatchingPotionCollection:
     def __iter__(self):
         return iter(self.__potions)
 
-    def __getitem__(self, name: str) -> HatchingPotion:
+    def __getitem__(self, name: str) -> HatchPotion:
         return self.__potions[name]
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.__potions=})"
 
-    def remove_hatching_potion(self, potion: HatchingPotion) -> "HatchingPotionCollection":
+    def remove_hatch_potion(self, potion: HatchPotion) -> "HatchPotionCollection":
         """Remove a single hatching potion from this collection.
 
         :param potion: The potion to remove.
-        :return: The updated HatchingPotionCollection
+        :return: The updated HatchPotionCollection
         """
         if self.__potions.get(potion.name) is None:
-            raise HatchingPotionException(
+            raise HatchPotionException(
                 f"{potion.name} was not in the collection {self.__potions}"
             )
         if self.__potions.get(potion.name).quantity == 0:
-            raise HatchingPotionException(
+            raise HatchPotionException(
                 f"We had 0 {potion.name} in the collection. Cannot remove any more."
             )
 

--- a/src/hopla/hoplalib/user/usermodels.py
+++ b/src/hopla/hoplalib/user/usermodels.py
@@ -51,7 +51,7 @@ class HabiticaUser:
     def get_pets(self) -> Dict[str, int]:
         """Return the pets of a user.
 
-        :return: A dictionary with pet_name as key and feeding_status as value.
+        :return: A dictionary with pet_name as key and feed_status as value.
         For example: {"Spider-Base": -1, "TRex-Skeleton": 5}
         """
         return self.get_inventory()["pets"]

--- a/src/hopla/hoplalib/user/usermodels.py
+++ b/src/hopla/hoplalib/user/usermodels.py
@@ -64,10 +64,10 @@ class HabiticaUser:
         """
         return self.get_inventory()["eggs"]
 
-    def get_hatching_potions(self) -> Dict[str, int]:
+    def get_hatch_potions(self) -> Dict[str, int]:
         """Return the hatching potions of a user.
 
-        :return: A dict with hatching_potion_names as keys and amount as value.
+        :return: A dict with hatch_potion_names as keys and amount as value.
         For example: { "Desert": 456, "Glow": 0}
         """
         return self.get_inventory()["hatchingPotions"]

--- a/src/hopla/hoplalib/zoo/feed_clickhelper.py
+++ b/src/hopla/hoplalib/zoo/feed_clickhelper.py
@@ -15,12 +15,12 @@ from hopla.hoplalib.outputformatter import JsonFormatter
 def get_feed_data_or_exit(feed_response: requests.Response) -> Union[NoReturn, dict]:
     """
     Given a feed response, if the API request was successful, return interesting
-    feeding information. On failure, exit with an error message.
+    feed information. On failure, exit with an error message.
     """
     response_json = feed_response.json()
     if response_json["success"]:
         feed_data = {
-            "feeding_status": response_json["data"],
+            "feed_status": response_json["data"],
             "message": response_json["message"]
         }
 

--- a/src/hopla/hoplalib/zoo/fooddata.py
+++ b/src/hopla/hoplalib/zoo/fooddata.py
@@ -9,7 +9,7 @@ class FoodData:
     the relationship between them.
     """
 
-    hatching_potion_favorite_food_mapping = {
+    hatch_potion_favorite_food_mapping = {
         "Base": "Meat",
         "White": "Milk",
         "Desert": "Potatoe",
@@ -38,10 +38,7 @@ class FoodData:
     * hopla api content | jq. wackyHatchingPotions
     """
 
-    drop_hatching_potions = list(hatching_potion_favorite_food_mapping.keys())
-    """A list of the non magic, non special hatching potions"""
-
-    drop_food_names = list(hatching_potion_favorite_food_mapping.values())
+    drop_food_names = list(hatch_potion_favorite_food_mapping.values())
     """A list of food items that can be dropped by doing tasks.
 
     These dont include cakes etc., those are rare collectibles.

--- a/src/hopla/hoplalib/zoo/foodmodels.py
+++ b/src/hopla/hoplalib/zoo/foodmodels.py
@@ -95,17 +95,17 @@ class FoodException(PrintableException):
 @dataclass(frozen=True)
 class Food:
     """A stockpile food item."""
-    food_name: str
+    name: str
 
     def __repr__(self) -> str:
-        return self.__class__.__name__ + f"({self.food_name})"
+        return self.__class__.__name__ + f"({self.name})"
 
     def is_rare_food_item(self) -> bool:
         """
         Return False if the food_item item is a drop food.
         Otherwise, return True.
         """
-        return self.food_name not in FoodData.drop_food_names
+        return self.name not in FoodData.drop_food_names
 
 
 @dataclass

--- a/src/hopla/hoplalib/zoo/foodmodels.py
+++ b/src/hopla/hoplalib/zoo/foodmodels.py
@@ -19,7 +19,7 @@ class InvalidFeedingStatus(PrintableException):
         self.pet = pet
 
 
-class FeedingStatus:
+class FeedStatus:
     """A class implementing feeding status logic for pets.
 
     Every freshly hatched pet starts at 5.
@@ -38,9 +38,9 @@ class FeedingStatus:
     NON_FAVORITE_INCREMENT: Final[int] = 2
 
     def __init__(self, feeding_status: int = START_FEEDING_STATE):
-        invalid_status = (feeding_status < FeedingStatus.PET_GREW_UP_TO_MOUNT
+        invalid_status = (feeding_status < FeedStatus.PET_GREW_UP_TO_MOUNT
                           or feeding_status in [1, 2, 3, 4]
-                          or feeding_status > FeedingStatus.MAX_FED_STATE)
+                          or feeding_status > FeedStatus.MAX_FED_STATE)
         if invalid_status:
             raise InvalidFeedingStatus(f"{feeding_status=} is invalid")
 
@@ -50,7 +50,7 @@ class FeedingStatus:
         return f"{self.__class__.__name__}({self.__feeding_status})"
 
     def __eq__(self, other):
-        return isinstance(other, FeedingStatus) and int(other) == int(self)
+        return isinstance(other, FeedStatus) and int(other) == int(self)
 
     def __hash__(self):
         return hash(self.__feeding_status)
@@ -61,16 +61,16 @@ class FeedingStatus:
     def is_pet_available(self):
         """Return True if the user currently has this pet."""
         return self.__feeding_status not in [
-            FeedingStatus.PET_GREW_UP_TO_MOUNT, FeedingStatus.PET_RELEASED
+            FeedStatus.PET_GREW_UP_TO_MOUNT, FeedStatus.PET_RELEASED
         ]
 
     def required_food_items_to_become_mount(self, is_favorite_food: bool) -> int:
         """Return how many items of food we need to give to turn a pet into a mount."""
-        target = FeedingStatus.FULLY_FED_STATE - self.__feeding_status
+        target = FeedStatus.FULLY_FED_STATE - self.__feeding_status
         if is_favorite_food:
-            required_food = math.ceil(target / FeedingStatus.FAVORITE_INCREMENT)
+            required_food = math.ceil(target / FeedStatus.FAVORITE_INCREMENT)
         else:
-            required_food = math.ceil(target / FeedingStatus.NON_FAVORITE_INCREMENT)
+            required_food = math.ceil(target / FeedStatus.NON_FAVORITE_INCREMENT)
         return required_food
 
     def to_percentage(self) -> int:

--- a/src/hopla/hoplalib/zoo/foodmodels.py
+++ b/src/hopla/hoplalib/zoo/foodmodels.py
@@ -11,7 +11,7 @@ from hopla.hoplalib.errors import PrintableException
 from hopla.hoplalib.zoo.fooddata import FoodData
 
 
-class InvalidFeedingStatus(PrintableException):
+class InvalidFeedStatus(PrintableException):
     """Exception raised when a pet is invalid."""
 
     def __init__(self, msg: str, *, pet=None):
@@ -20,53 +20,53 @@ class InvalidFeedingStatus(PrintableException):
 
 
 class FeedStatus:
-    """A class implementing feeding status logic for pets.
+    """A class implementing feed status logic for pets.
 
     Every freshly hatched pet starts at 5.
     50 would turn the pet into a mount, so 50 is impossible to reach.
-    The feeding status of 0 means that you had the pet before, but
+    The feed status of 0 means that you had the pet before, but
     you released it.
     """
     PET_GREW_UP_TO_MOUNT: Final[int] = -1
     PET_RELEASED: Final[int] = 0
 
-    START_FEEDING_STATE: Final[int] = 5
+    START_FEED_STATE: Final[int] = 5
     MAX_FED_STATE: Final[int] = 49
     FULLY_FED_STATE: Final[int] = 50
 
     FAVORITE_INCREMENT: Final[int] = 5
     NON_FAVORITE_INCREMENT: Final[int] = 2
 
-    def __init__(self, feeding_status: int = START_FEEDING_STATE):
-        invalid_status = (feeding_status < FeedStatus.PET_GREW_UP_TO_MOUNT
-                          or feeding_status in [1, 2, 3, 4]
-                          or feeding_status > FeedStatus.MAX_FED_STATE)
+    def __init__(self, feed_status: int = START_FEED_STATE):
+        invalid_status = (feed_status < FeedStatus.PET_GREW_UP_TO_MOUNT
+                          or feed_status in [1, 2, 3, 4]
+                          or feed_status > FeedStatus.MAX_FED_STATE)
         if invalid_status:
-            raise InvalidFeedingStatus(f"{feeding_status=} is invalid")
+            raise InvalidFeedStatus(f"{feed_status=} is invalid")
 
-        self.__feeding_status = feeding_status
+        self.__feed_status = feed_status
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}({self.__feeding_status})"
+        return f"{self.__class__.__name__}({self.__feed_status})"
 
     def __eq__(self, other):
         return isinstance(other, FeedStatus) and int(other) == int(self)
 
     def __hash__(self):
-        return hash(self.__feeding_status)
+        return hash(self.__feed_status)
 
     def __int__(self) -> int:
-        return self.__feeding_status
+        return self.__feed_status
 
     def is_pet_available(self):
         """Return True if the user currently has this pet."""
-        return self.__feeding_status not in [
+        return self.__feed_status not in [
             FeedStatus.PET_GREW_UP_TO_MOUNT, FeedStatus.PET_RELEASED
         ]
 
     def required_food_items_to_become_mount(self, is_favorite_food: bool) -> int:
         """Return how many items of food we need to give to turn a pet into a mount."""
-        target = FeedStatus.FULLY_FED_STATE - self.__feeding_status
+        target = FeedStatus.FULLY_FED_STATE - self.__feed_status
         if is_favorite_food:
             required_food = math.ceil(target / FeedStatus.FAVORITE_INCREMENT)
         else:
@@ -75,13 +75,13 @@ class FeedStatus:
 
     def to_percentage(self) -> int:
         """
-        Turn feeding status into percentage understandable by the
+        Turn feed status into percentage understandable by the
         website user.
         <https://habitica.fandom.com/wiki/Food_Preferences>
         """
-        if self.__feeding_status == -1:
+        if self.__feed_status == -1:
             return 100  # The pet is now a mount
-        return self.__feeding_status * 2
+        return self.__feed_status * 2
 
 
 class FoodException(PrintableException):

--- a/src/hopla/hoplalib/zoo/petcontroller.py
+++ b/src/hopla/hoplalib/zoo/petcontroller.py
@@ -6,8 +6,8 @@ from typing import NoReturn, Optional, Union
 import requests
 
 from hopla.hoplalib.http import HabiticaRequest, UrlBuilder
-from hopla.hoplalib.zoo.feeding_clickhelper import get_feed_data_or_exit
-from hopla.hoplalib.zoo.zoofeeding_algorithms import FeedPlanItem
+from hopla.hoplalib.zoo.feed_clickhelper import get_feed_data_or_exit
+from hopla.hoplalib.zoo.zoofeed_algorithms import FeedPlanItem
 
 
 class FeedPostRequester(HabiticaRequest):
@@ -49,7 +49,7 @@ class FeedPostRequester(HabiticaRequest):
     def post_feed_request_get_data_or_exit(self) -> Union[NoReturn, dict]:
         """
         Performs the feed pet post requests and return
-        the feeding response if successful. Else exit
+        the feed response if successful. Else exit
 
         :return:
         """

--- a/src/hopla/hoplalib/zoo/petmodels.py
+++ b/src/hopla/hoplalib/zoo/petmodels.py
@@ -43,21 +43,21 @@ class Pet:
                              "* Is your pet relatively new? If so, please raise\n"
                              f" an issue at {GlobalConstants.NEW_ISSUE_URL}")
 
-        self.pet_name = pet_name
+        self.name = pet_name
         self.feed_status = feed_status
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}({self.pet_name}: {self.feed_status})"
+        return f"{self.__class__.__name__}({self.name}: {self.feed_status})"
 
     @property
     def hatch_potion_name(self) -> Optional[str]:
         """The hatching potion used to hatch the egg this pet came from."""
-        if self.pet_name in PetData.rare_pet_names:
+        if self.name in PetData.rare_pet_names:
             return None
 
         # This logic might break, but seems to be solid for past few years due to
         # stabling naming convention by the Habitica API developers.
-        _, potion = self.pet_name.split("-")
+        _, potion = self.name.split("-")
         return potion
 
     def is_available(self) -> bool:
@@ -66,38 +66,38 @@ class Pet:
 
     def is_feedable(self) -> bool:
         """Return True if a pet cannot be fed at all."""
-        return self.pet_name not in PetData.unfeedable_pet_names
+        return self.name not in PetData.unfeedable_pet_names
 
     def has_just_1_favorite_food(self) -> bool:
         """Return True if this pet likes only 1 type of food."""
-        return self.pet_name in PetData.only_1favorite_food_pet_names
+        return self.name in PetData.only_1favorite_food_pet_names
 
     def likes_all_food(self) -> bool:
         """Return True if this pet prefers all food."""
-        return self.pet_name in PetData.magic_potion_pet_names
+        return self.name in PetData.magic_potion_pet_names
 
     def feed_status_explanation(self) -> str:
         """Explain the feed status of a pet."""
         if self.is_feedable() is False:
-            return f"{self.pet_name} is an unfeedable pet."
+            return f"{self.name} is an unfeedable pet."
         if int(self.feed_status) == 0:
-            return f"You released {self.pet_name}, so you cannot feed it."
+            return f"You released {self.name}, so you cannot feed it."
 
         if int(self.feed_status) == -1:
-            return f"You can't feed {self.pet_name=} you only have the mount"
+            return f"You can't feed {self.name=} you only have the mount"
 
         if int(self.feed_status) == 5:
             # remark: if we really want to know more, we can query the
-            #         API to check if we have the self.pet_name in the
+            #         API to check if we have the self.name in the
             #         Users: jq .data.items.mounts
-            return (f"Cannot determine if {self.pet_name=} can be fed. \n"
+            return (f"Cannot determine if {self.name=} can be fed. \n"
                     "You either have:\n"
                     "1. Both the pet and mount. In this case, you cannot feed the pet \n"
                     "2. A pet that hasn't been fed but you don't have \n"
                     "   the mount. In this case, you can feed your pet")
 
         if int(self.feed_status) < 50:
-            return f"{self.pet_name=} can be fed"
+            return f"{self.name=} can be fed"
 
         raise InvalidPet(f"Did not expect {self.feed_status=}. \n"
                          f"Looks like we failed to validate the Pet properly.",
@@ -110,14 +110,14 @@ class Pet:
         if self.is_feedable() is False:
             return default_value_for_unfeedable
 
-        if self.pet_name in PetData.magic_potion_pet_names:
+        if self.name in PetData.magic_potion_pet_names:
             return default_value_for_all_favorite_food
 
         if self.has_just_1_favorite_food():
             return (FoodData.hatch_potion_favorite_food_mapping
                     .get(self.hatch_potion_name))
 
-        raise InvalidPet(f"Could not find the feed habits of this {self.pet_name=}",
+        raise InvalidPet(f"Could not find the feed habits of this {self.name=}",
                          pet=self)  # pragma: no cover
 
     def is_favorite_food(self, food_name: str) -> bool:
@@ -129,7 +129,7 @@ class Pet:
         if self.has_just_1_favorite_food():
             return self.favorite_food() == food_name
 
-        raise InvalidPet(f"Unable to determine if {food_name=} is {self.pet_name=}'s favorite.",
+        raise InvalidPet(f"Unable to determine if {food_name=} is {self.name=}'s favorite.",
                          pet=self)  # pragma: no cover
 
     def required_food_items_until_mount(self, food_name: str) -> int:
@@ -142,18 +142,18 @@ class Pet:
 
     def is_generation1_pet(self) -> bool:
         """Return True if this pet is from the generation 1 pet"""
-        return self.pet_name in PetData.generation1_pet_names
+        return self.name in PetData.generation1_pet_names
 
     def is_quest_pet(self) -> bool:
         """
         Return True if this pet is a quest pet. This doesn't include
         special pets such as world event related pets.
         """
-        return self.pet_name in PetData.quest_pet_names
+        return self.name in PetData.quest_pet_names
 
     def is_magic_hatch_pet(self) -> bool:
         """Return True if this pet is hatched from a magic potion."""
-        return self.pet_name in PetData.magic_potion_pet_names
+        return self.name in PetData.magic_potion_pet_names
 
     def is_from_drop_hatch_potions(self) -> bool:
         """
@@ -205,8 +205,8 @@ class PetMountPair:
         Raise an exception if the names of the pet and mount do not match.
         """
         if pet and mount:
-            if pet.pet_name != mount.mount_name:
-                msg = f"pet name '{pet.pet_name}' must equal mount name '{mount.mount_name}'"
+            if pet.name != mount.mount_name:
+                msg = f"pet name '{pet.name}' must equal mount name '{mount.mount_name}'"
                 raise InvalidPetMountPair(msg)
 
         self.pet = pet

--- a/src/hopla/hoplalib/zoo/petmodels.py
+++ b/src/hopla/hoplalib/zoo/petmodels.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 from hopla.hoplalib.common import GlobalConstants
 from hopla.hoplalib.errors import PrintableException, YouFoundABugRewardError
+from hopla.hoplalib.hatchery.hatchdata import HatchPotionData
 from hopla.hoplalib.zoo.fooddata import FoodData
 from hopla.hoplalib.zoo.foodmodels import FeedStatus
 from hopla.hoplalib.zoo.petdata import PetData
@@ -49,7 +50,7 @@ class Pet:
         return f"{self.__class__.__name__}({self.pet_name}: {self.feed_status})"
 
     @property
-    def hatching_potion(self) -> Optional[str]:
+    def hatch_potion_name(self) -> Optional[str]:
         """The hatching potion used to hatch the egg this pet came from."""
         if self.pet_name in PetData.rare_pet_names:
             return None
@@ -113,8 +114,8 @@ class Pet:
             return default_value_for_all_favorite_food
 
         if self.has_just_1_favorite_food():
-            return (FoodData.hatching_potion_favorite_food_mapping
-                    .get(self.hatching_potion))
+            return (FoodData.hatch_potion_favorite_food_mapping
+                    .get(self.hatch_potion_name))
 
         raise InvalidPet(f"Could not find the feed habits of this {self.pet_name=}",
                          pet=self)  # pragma: no cover
@@ -150,16 +151,16 @@ class Pet:
         """
         return self.pet_name in PetData.quest_pet_names
 
-    def is_magic_hatching_pet(self) -> bool:
+    def is_magic_hatch_pet(self) -> bool:
         """Return True if this pet is hatched from a magic potion."""
         return self.pet_name in PetData.magic_potion_pet_names
 
-    def is_from_drop_hatching_potions(self) -> bool:
+    def is_from_drop_hatch_potions(self) -> bool:
         """
         Return True if the pet was hatched from one of the 'ordinary'
         potions. (Such as: Base, Desert, ...).
         """
-        return self.hatching_potion in FoodData.drop_hatching_potions
+        return self.hatch_potion_name in HatchPotionData.drop_hatch_potion_names
 
 
 @dataclass

--- a/src/hopla/hoplalib/zoo/petmodels.py
+++ b/src/hopla/hoplalib/zoo/petmodels.py
@@ -179,11 +179,11 @@ class Mount:
         :param mount_name:
         :param availability_status:
         """
-        self.mount_name = mount_name
+        self.name = mount_name
         self._availability_status = availability_status
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}({self.mount_name}: {self._availability_status})"
+        return f"{self.__class__.__name__}({self.name}: {self._availability_status})"
 
     def is_available(self) -> bool:
         """Return true if the user has the mount right now."""
@@ -205,8 +205,8 @@ class PetMountPair:
         Raise an exception if the names of the pet and mount do not match.
         """
         if pet and mount:
-            if pet.name != mount.mount_name:
-                msg = f"pet name '{pet.name}' must equal mount name '{mount.mount_name}'"
+            if pet.name != mount.name:
+                msg = f"pet name '{pet.name}' must equal mount name '{mount.name}'"
                 raise InvalidPetMountPair(msg)
 
         self.pet = pet

--- a/src/hopla/hoplalib/zoo/petmodels.py
+++ b/src/hopla/hoplalib/zoo/petmodels.py
@@ -34,7 +34,7 @@ class Pet:
     #################################################################
 
     def __init__(self, pet_name: str, *,
-                 feeding_status: FeedStatus = FeedStatus(5)):
+                 feed_status: FeedStatus = FeedStatus(5)):
         if pet_name not in PetData.pet_names:
             raise InvalidPet(f"{pet_name=} is not recognized by hopla.\n"
                              "Potential causes: \n"
@@ -43,10 +43,10 @@ class Pet:
                              f" an issue at {GlobalConstants.NEW_ISSUE_URL}")
 
         self.pet_name = pet_name
-        self.feeding_status = feeding_status
+        self.feed_status = feed_status
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}({self.pet_name}: {self.feeding_status})"
+        return f"{self.__class__.__name__}({self.pet_name}: {self.feed_status})"
 
     @property
     def hatching_potion(self) -> Optional[str]:
@@ -60,8 +60,8 @@ class Pet:
         return potion
 
     def is_available(self) -> bool:
-        """Return True if the feeding status says that the pet is available."""
-        return self.feeding_status.is_pet_available()
+        """Return True if the feed status says that the pet is available."""
+        return self.feed_status.is_pet_available()
 
     def is_feedable(self) -> bool:
         """Return True if a pet cannot be fed at all."""
@@ -75,17 +75,17 @@ class Pet:
         """Return True if this pet prefers all food."""
         return self.pet_name in PetData.magic_potion_pet_names
 
-    def feeding_status_explanation(self) -> str:
-        """Explain the feeding status of a pet."""
+    def feed_status_explanation(self) -> str:
+        """Explain the feed status of a pet."""
         if self.is_feedable() is False:
             return f"{self.pet_name} is an unfeedable pet."
-        if int(self.feeding_status) == 0:
+        if int(self.feed_status) == 0:
             return f"You released {self.pet_name}, so you cannot feed it."
 
-        if int(self.feeding_status) == -1:
+        if int(self.feed_status) == -1:
             return f"You can't feed {self.pet_name=} you only have the mount"
 
-        if int(self.feeding_status) == 5:
+        if int(self.feed_status) == 5:
             # remark: if we really want to know more, we can query the
             #         API to check if we have the self.pet_name in the
             #         Users: jq .data.items.mounts
@@ -95,10 +95,10 @@ class Pet:
                     "2. A pet that hasn't been fed but you don't have \n"
                     "   the mount. In this case, you can feed your pet")
 
-        if int(self.feeding_status) < 50:
+        if int(self.feed_status) < 50:
             return f"{self.pet_name=} can be fed"
 
-        raise InvalidPet(f"Did not expect {self.feeding_status=}. \n"
+        raise InvalidPet(f"Did not expect {self.feed_status=}. \n"
                          f"Looks like we failed to validate the Pet properly.",
                          pet=self)  # pragma: no cover
 
@@ -116,7 +116,7 @@ class Pet:
             return (FoodData.hatching_potion_favorite_food_mapping
                     .get(self.hatching_potion))
 
-        raise InvalidPet(f"Could not find the feeding habits of this {self.pet_name=}",
+        raise InvalidPet(f"Could not find the feed habits of this {self.pet_name=}",
                          pet=self)  # pragma: no cover
 
     def is_favorite_food(self, food_name: str) -> bool:
@@ -137,7 +137,7 @@ class Pet:
         for this pet to turn into a mount
         """
         is_favorite: bool = self.is_favorite_food(food_name)
-        return self.feeding_status.required_food_items_to_become_mount(is_favorite)
+        return self.feed_status.required_food_items_to_become_mount(is_favorite)
 
     def is_generation1_pet(self) -> bool:
         """Return True if this pet is from the generation 1 pet"""

--- a/src/hopla/hoplalib/zoo/petmodels.py
+++ b/src/hopla/hoplalib/zoo/petmodels.py
@@ -7,7 +7,7 @@ from typing import Optional
 from hopla.hoplalib.common import GlobalConstants
 from hopla.hoplalib.errors import PrintableException, YouFoundABugRewardError
 from hopla.hoplalib.zoo.fooddata import FoodData
-from hopla.hoplalib.zoo.foodmodels import FeedingStatus
+from hopla.hoplalib.zoo.foodmodels import FeedStatus
 from hopla.hoplalib.zoo.petdata import PetData
 
 
@@ -34,7 +34,7 @@ class Pet:
     #################################################################
 
     def __init__(self, pet_name: str, *,
-                 feeding_status: FeedingStatus = FeedingStatus(5)):
+                 feeding_status: FeedStatus = FeedStatus(5)):
         if pet_name not in PetData.pet_names:
             raise InvalidPet(f"{pet_name=} is not recognized by hopla.\n"
                              "Potential causes: \n"

--- a/src/hopla/hoplalib/zoo/zoofeed_algorithms.py
+++ b/src/hopla/hoplalib/zoo/zoofeed_algorithms.py
@@ -66,9 +66,9 @@ class ZookeeperFeedPlan:
 
     @property
     def feed_plan(self) -> List[FeedPlanItem]:
-        """Return the feeding plan.
+        """Return the feed plan.
 
-        :return: The feeding plan. This will be empty when
+        :return: The feed plan. This will be empty when
         no feed plan items have been added yet.
         """
         return self.__feed_plan
@@ -79,7 +79,7 @@ class ZookeeperFeedPlan:
 
 
 @dataclass
-class ZooFeedingAlgorithm:
+class ZooFeedAlgorithm:
     """
     This class contains an algorithm that makes a plan to distribute food
     from a food stockpile over pets in a zoo.
@@ -114,8 +114,8 @@ class ZooFeedingAlgorithm:
     def make_plan(self) -> ZookeeperFeedPlan:
         """Make the plan.
 
-        This function removes food from the stockpile and adds feeding items
-        to the feeding plan.
+        This function removes food from the stockpile and adds feed items
+        to the feed plan.
         """
         helper = ZooHelper(self.__zoo)
         gen1_zoo: Zoo = helper.filter_on_pet(Pet.is_generation1_pet)

--- a/src/hopla/hoplalib/zoo/zoofeed_algorithms.py
+++ b/src/hopla/hoplalib/zoo/zoofeed_algorithms.py
@@ -120,7 +120,7 @@ class ZooFeedAlgorithm:
         helper = ZooHelper(self.__zoo)
         gen1_zoo: Zoo = helper.filter_on_pet(Pet.is_generation1_pet)
         quest_zoo: Zoo = helper.filter_on_pet(Pet.is_quest_pet)
-        magic_zoo: Zoo = helper.filter_on_pet(Pet.is_magic_hatching_pet)
+        magic_zoo: Zoo = helper.filter_on_pet(Pet.is_magic_hatch_pet)
 
         self.__make_plan(gen1_zoo)
         self.__make_plan(quest_zoo)

--- a/src/hopla/hoplalib/zoo/zoomodels.py
+++ b/src/hopla/hoplalib/zoo/zoomodels.py
@@ -78,7 +78,7 @@ class ZooBuilder:
 
         # loop through the pets
         for pet_name, feed_status in self.pets.items():
-            pet = Pet(pet_name, feeding_status=FeedStatus(feed_status))
+            pet = Pet(pet_name, feed_status=FeedStatus(feed_status))
 
             if self.mounts.get(pet_name) is not None:
                 mount = Mount(

--- a/src/hopla/hoplalib/zoo/zoomodels.py
+++ b/src/hopla/hoplalib/zoo/zoomodels.py
@@ -6,7 +6,7 @@ from typing import Callable, Dict
 from dataclasses import dataclass
 
 from hopla.cli.groupcmds.get_user import HabiticaUser
-from hopla.hoplalib.zoo.foodmodels import FeedingStatus
+from hopla.hoplalib.zoo.foodmodels import FeedStatus
 from hopla.hoplalib.zoo.petmodels import Mount, Pet, PetMountPair
 
 Zoo = Dict[str, PetMountPair]
@@ -78,7 +78,7 @@ class ZooBuilder:
 
         # loop through the pets
         for pet_name, feed_status in self.pets.items():
-            pet = Pet(pet_name, feeding_status=FeedingStatus(feed_status))
+            pet = Pet(pet_name, feeding_status=FeedStatus(feed_status))
 
             if self.mounts.get(pet_name) is not None:
                 mount = Mount(

--- a/src/tests/cli/get_user/test_info.py
+++ b/src/tests/cli/get_user/test_info.py
@@ -56,7 +56,7 @@ def get_test_user() -> HabiticaUser:
     * long lists have been cut down significantly to remove the duplication
       of data that is largely similar in syntax (.g. finished quests).
       The was to keep the original range of data intact (e.g. at least
-      keep a large value, negative value, and default value for feeding
+      keep a large value, negative value, and default value for feed
       status of pets. e.g. within 'history' dates came in multiple formats,
       (millis and iso dates) so both formats were kept).
     * care was taken to not modify the underlying structure and

--- a/src/tests/cli/test_feed.py
+++ b/src/tests/cli/test_feed.py
@@ -47,9 +47,9 @@ class TestFeedCliCommand:
         pet_name = "Wolf-Zombie"
         food_name = "RottenMeat"
 
-        feeding_status_expected = 15
+        feed_status_expected = 15
         message_expected = f"{pet_name} really likes the Rotten Meat!"
-        response_content = {"success": True, "data": feeding_status_expected,
+        response_content = {"success": True, "data": feed_status_expected,
                             "message": message_expected, "userV": 59173,
                             "appVersion": "4.205.1"}
 
@@ -60,7 +60,7 @@ class TestFeedCliCommand:
 
         mock_feed_api_call.assert_called_once_with()  # no args
         assert result.exit_code == 0
-        assert f'"feeding_status": {feeding_status_expected},' in result.output
+        assert f'"feed_status": {feed_status_expected},' in result.output
         assert f'"message": "{message_expected}"' in result.output
 
     @pytest.mark.parametrize(
@@ -76,13 +76,13 @@ class TestFeedCliCommand:
     def test_feed_pet_with_favorite_food_ok(self, mock_feed_api_call: MagicMock,
                                             pet_name: str,
                                             expected_favorite_food: str):
-        feeding_status_expected = 10
+        feed_status_expected = 10
         # Side note: This message_expected variable is not perfect because the user' 'text'
         # naming for pets and foods differs often slightly from their 'key'
         # values (e.g. RottenMeat vs. Rotten Meat, DolphinRed vs. Red Dolphin). But that
         # is not relevant here, so we are happy anyways.
         message_expected = f'{pet_name} really likes the {expected_favorite_food}!'
-        response_content = {'success': True, 'data': feeding_status_expected,
+        response_content = {'success': True, 'data': feed_status_expected,
                             'message': message_expected}
         mock_feed_api_call.return_value = MockFeedResponse(json=response_content)
 
@@ -91,7 +91,7 @@ class TestFeedCliCommand:
 
         mock_feed_api_call.assert_called_once_with()  # no args
         assert result.exit_code == 0
-        assert f'"feeding_status": {feeding_status_expected},' in result.output
+        assert f'"feed_status": {feed_status_expected},' in result.output
         assert f'"message": "{message_expected}"' in result.output
 
     @patch("hopla.cli.feed.HabiticaUserRequest.request_user_data_or_exit")
@@ -118,7 +118,7 @@ class TestFeedCliCommand:
         result: Result = runner.invoke(feed, [magic_pet_name])
 
         assert result.exit_code == 0
-        assert f'"feeding_status": {expected_feed_data}' in result.stdout
+        assert f'"feed_status": {expected_feed_data}' in result.stdout
         assert f'"message": "{expected_msg}"' in result.stdout
 
     @patch("hopla.cli.feed.FeedPostRequester.post_feed_request")
@@ -191,7 +191,7 @@ class TestFeedCliCommand:
         )
         assert result.exit_code == 0
         assert response_msg in result.stdout
-        assert f'"feeding_status": {response_data}' in result.stdout
+        assert f'"feed_status": {response_data}' in result.stdout
 
 
 class TestPrintFavoriteFood:

--- a/src/tests/cli/test_feed_all.py
+++ b/src/tests/cli/test_feed_all.py
@@ -99,7 +99,7 @@ class TestFeedAllCliCommand:
         assert "Pet Velociraptor-Skeleton will get 8 Fish.\n" in result.stdout
         assert f"Do you want to proceed? [y/N]: {yes_response}\n" in result.stdout
         assert feed_msg in result.stdout
-        assert '"feeding_status": -1' in result.stdout
+        assert '"feed_status": -1' in result.stdout
         assert result.exit_code == 0
 
     @pytest.mark.parametrize("yes_response", yes_responses)

--- a/src/tests/cli/test_hatch_all.py
+++ b/src/tests/cli/test_hatch_all.py
@@ -118,9 +118,9 @@ class TestToPetList:
         result: List[Pet] = to_pet_list(pets)
 
         expected: List[Pet] = [
-            Pet(pet1, feeding_status=FeedStatus(feed_status1)),
-            Pet(pet2, feeding_status=FeedStatus(feed_status2)),
-            Pet(pet3, feeding_status=FeedStatus(feed_status3)),
-            Pet(pet4, feeding_status=FeedStatus(feed_status4))
+            Pet(pet1, feed_status=FeedStatus(feed_status1)),
+            Pet(pet2, feed_status=FeedStatus(feed_status2)),
+            Pet(pet3, feed_status=FeedStatus(feed_status3)),
+            Pet(pet4, feed_status=FeedStatus(feed_status4))
         ]
         assert result == expected

--- a/src/tests/cli/test_hatch_all.py
+++ b/src/tests/cli/test_hatch_all.py
@@ -6,7 +6,7 @@ from click.testing import CliRunner, Result
 
 from hopla.cli.hatch_all import hatch_all, to_pet_list
 from hopla.hoplalib.user.usermodels import HabiticaUser
-from hopla.hoplalib.zoo.foodmodels import FeedingStatus
+from hopla.hoplalib.zoo.foodmodels import FeedStatus
 from hopla.hoplalib.zoo.petmodels import Pet
 
 
@@ -118,9 +118,9 @@ class TestToPetList:
         result: List[Pet] = to_pet_list(pets)
 
         expected: List[Pet] = [
-            Pet(pet1, feeding_status=FeedingStatus(feed_status1)),
-            Pet(pet2, feeding_status=FeedingStatus(feed_status2)),
-            Pet(pet3, feeding_status=FeedingStatus(feed_status3)),
-            Pet(pet4, feeding_status=FeedingStatus(feed_status4))
+            Pet(pet1, feeding_status=FeedStatus(feed_status1)),
+            Pet(pet2, feeding_status=FeedStatus(feed_status2)),
+            Pet(pet3, feeding_status=FeedStatus(feed_status3)),
+            Pet(pet4, feeding_status=FeedStatus(feed_status4))
         ]
         assert result == expected

--- a/src/tests/hoplalib/hatchery/test_eggmodels.py
+++ b/src/tests/hoplalib/hatchery/test_eggmodels.py
@@ -6,8 +6,8 @@ import pytest
 
 from hopla.hoplalib.errors import YouFoundABugRewardError
 from hopla.hoplalib.hatchery.eggmodels import Egg, EggCollection, EggException
-from hopla.hoplalib.hatchery.hatchdata import EggData, HatchingPotionData
-from hopla.hoplalib.hatchery.hatchpotionmodels import HatchingPotion
+from hopla.hoplalib.hatchery.hatchdata import EggData, HatchPotionData
+from hopla.hoplalib.hatchery.hatchpotionmodels import HatchPotion
 
 _SAMPLE_SIZE = 9
 
@@ -60,12 +60,12 @@ class TestEgg:
     @pytest.mark.parametrize(
         "egg_name,potion_name",
         list(zip(EggData.drop_egg_names,
-                 HatchingPotionData.hatching_potion_names))
+                 HatchPotionData.hatch_potion_names))
     )
     def test_can_be_hatched_by_standard_egg_true(self, egg_name: str,
                                                  potion_name: str):
         egg = Egg(egg_name)
-        potion = HatchingPotion(potion_name)
+        potion = HatchPotion(potion_name)
 
         # standard eggs can be hatched by any potion
         assert egg.can_be_hatched_by(potion) is True
@@ -73,13 +73,13 @@ class TestEgg:
     @pytest.mark.parametrize(
         "egg_name,potion_name",
         list(zip(EggData.quest_egg_names,
-                 HatchingPotionData.drop_hatching_potion_names))
+                 HatchPotionData.drop_hatch_potion_names))
     )
     def test_can_be_hatched_by_magic_egg_drop_potion_true(self,
                                                           egg_name: str,
                                                           potion_name: str):
         egg = Egg(egg_name)
-        potion = HatchingPotion(potion_name)
+        potion = HatchPotion(potion_name)
 
         # quest eggs can be hatched by standard potion
         assert egg.can_be_hatched_by(potion) is True
@@ -88,14 +88,14 @@ class TestEgg:
         "egg_name,potion_name",
         list(zip(
             random.sample(EggData.quest_egg_names, k=_SAMPLE_SIZE),
-            random.sample(HatchingPotionData.non_drop_hatching_potion_names, k=_SAMPLE_SIZE)
+            random.sample(HatchPotionData.non_drop_hatch_potion_names, k=_SAMPLE_SIZE)
         ))
     )
     def test_can_be_hatched_by_magic_egg_non_drop_potion_false(self,
                                                                egg_name: str,
                                                                potion_name: str):
         egg = Egg(egg_name)
-        potion = HatchingPotion(potion_name)
+        potion = HatchPotion(potion_name)
 
         # quest eggs cannot be hatched by non standard potion
         assert egg.can_be_hatched_by(potion) is False

--- a/src/tests/hoplalib/hatchery/test_hatchalgorithm.py
+++ b/src/tests/hoplalib/hatchery/test_hatchalgorithm.py
@@ -142,7 +142,7 @@ class TestHatchPlan:
         assert HatchPlanItem(egg, potion) in hatch_plan
 
     def test_remove_hatching_if_pet_available_yes_available_ok(self):
-        pets: List[Pet] = [Pet("Wolf-Ghost", feeding_status=FeedStatus(5))]
+        pets: List[Pet] = [Pet("Wolf-Ghost", feed_status=FeedStatus(5))]
         egg = Egg("Wolf")
         potion = HatchingPotion("Ghost")
         hatch_plan = HatchPlan().add(egg=egg, potion=potion)
@@ -155,10 +155,10 @@ class TestHatchPlan:
     def test_remove_hatching_if_pet_available_yes_and_no_available_ok(self):
         # 1. Wolf-Ghost is available, so that one should be filtered out.
         # 2. However, even though Wolf-Base is in the list, it is not available because
-        #    feedings status is -1.
+        #    feed status is -1.
         pets: List[Pet] = [
-            Pet("Wolf-Ghost", feeding_status=FeedStatus(5)),
-            Pet("Wolf-Base", feeding_status=FeedStatus(-1))
+            Pet("Wolf-Ghost", feed_status=FeedStatus(5)),
+            Pet("Wolf-Base", feed_status=FeedStatus(-1))
         ]
         egg = Egg("Wolf")
         ghost_potion = HatchingPotion("Ghost")

--- a/src/tests/hoplalib/hatchery/test_hatchalgorithm.py
+++ b/src/tests/hoplalib/hatchery/test_hatchalgorithm.py
@@ -5,7 +5,7 @@ import pytest
 
 from hopla.hoplalib.hatchery.eggmodels import Egg, EggCollection
 from hopla.hoplalib.hatchery.hatchalgorithms import HatchPlan, HatchPlanItem, HatchPlanMaker
-from hopla.hoplalib.hatchery.hatchpotionmodels import HatchingPotion, HatchingPotionCollection
+from hopla.hoplalib.hatchery.hatchpotionmodels import HatchPotion, HatchPotionCollection
 from hopla.hoplalib.zoo.foodmodels import FeedStatus
 from hopla.hoplalib.zoo.petmodels import Pet
 
@@ -14,7 +14,7 @@ class TestHatchPlanItem:
     def test__repr__ok(self):
         egg_name, potion_name = "Wolf", "Aquatic"
         egg = Egg(egg_name, quantity=2)
-        potion = HatchingPotion(potion_name, quantity=3)
+        potion = HatchPotion(potion_name, quantity=3)
         plan_item = HatchPlanItem(egg=egg, potion=potion)
 
         result: str = repr(plan_item)
@@ -24,7 +24,7 @@ class TestHatchPlanItem:
     def test__eq__should_eq_self_ok(self):
         egg_name, potion_name = "Snake", "Base"
         egg = Egg(egg_name)
-        potion = HatchingPotion(potion_name)
+        potion = HatchPotion(potion_name)
         item = HatchPlanItem(egg=egg, potion=potion)
 
         assert item == item
@@ -34,40 +34,40 @@ class TestHatchPlanItem:
 
         item_self = HatchPlanItem(
             egg=Egg(egg_name, quantity=2),
-            potion=HatchingPotion(potion_name, quantity=3)
+            potion=HatchPotion(potion_name, quantity=3)
         )
 
         item_other = HatchPlanItem(
             egg=Egg(egg_name, quantity=12),
-            potion=HatchingPotion(potion_name, quantity=103)
+            potion=HatchPotion(potion_name, quantity=103)
         )
 
         assert item_self == item_other
 
     def test__eq__different_egg_name_false(self):
         potion_name = "Base"
-        item_self = HatchPlanItem(egg=Egg("Snake"), potion=HatchingPotion(potion_name))
-        item_other = HatchPlanItem(egg=Egg("Horse"), potion=HatchingPotion(potion_name))
+        item_self = HatchPlanItem(egg=Egg("Snake"), potion=HatchPotion(potion_name))
+        item_other = HatchPlanItem(egg=Egg("Horse"), potion=HatchPotion(potion_name))
 
         assert item_self != item_other
 
     def test__eq__different_potion_name_false(self):
         egg_name = "Horse"
-        item_self = HatchPlanItem(egg=Egg(egg_name), potion=HatchingPotion("Base"))
-        item_other = HatchPlanItem(egg=Egg(egg_name), potion=HatchingPotion("CottonCandyBlue"))
+        item_self = HatchPlanItem(egg=Egg(egg_name), potion=HatchPotion("Base"))
+        item_other = HatchPlanItem(egg=Egg(egg_name), potion=HatchPotion("CottonCandyBlue"))
 
         assert item_self != item_other
 
     def test__eq__different_thing_false(self):
-        item_self = HatchPlanItem(egg=Egg("Horse"), potion=HatchingPotion("Base"))
+        item_self = HatchPlanItem(egg=Egg("Horse"), potion=HatchPotion("Base"))
 
         assert item_self != Egg("Snake")
-        assert item_self != HatchingPotion("Base")
+        assert item_self != HatchPotion("Base")
 
     def test_format_item(self):
         egg_name = "Snake"
         potion_name = "Base"
-        item = HatchPlanItem(egg=Egg(egg_name), potion=HatchingPotion(potion_name))
+        item = HatchPlanItem(egg=Egg(egg_name), potion=HatchPotion(potion_name))
 
         result: str = item.format_item()
 
@@ -91,7 +91,7 @@ class TestHatchPlan:
         hatch_plan = HatchPlan()
         egg_name = "Horse"
         potion_name = "CottonCandyBlue"
-        hatch_plan.add(egg=Egg(egg_name), potion=HatchingPotion(potion_name))
+        hatch_plan.add(egg=Egg(egg_name), potion=HatchPotion(potion_name))
 
         result: str = repr(hatch_plan)
 
@@ -99,8 +99,8 @@ class TestHatchPlan:
 
     def test_format_plan(self):
         plan = HatchPlan() \
-            .add(egg=Egg("Fox"), potion=HatchingPotion("Dessert")) \
-            .add(egg=Egg("Seahorse"), potion=HatchingPotion("Desert"))
+            .add(egg=Egg("Fox"), potion=HatchPotion("Dessert")) \
+            .add(egg=Egg("Seahorse"), potion=HatchPotion("Desert"))
 
         result: str = plan.format_plan()
 
@@ -117,42 +117,42 @@ class TestHatchPlan:
         assert len(plan) == 0
 
     def test_is_empty_false(self):
-        plan = HatchPlan().add(egg=Egg("Egg"), potion=HatchingPotion("Red"))
+        plan = HatchPlan().add(egg=Egg("Egg"), potion=HatchPotion("Red"))
         assert plan.is_empty() is False
         assert len(plan) == 1
 
     def test_add_ok(self):
         hatch_plan = HatchPlan()
         egg = Egg("Seahorse")
-        potion = HatchingPotion("Skeleton")
+        potion = HatchPotion("Skeleton")
         hatch_plan.add(egg=egg, potion=potion)
 
         assert len(hatch_plan) == 1
         assert HatchPlanItem(egg, potion) in hatch_plan
 
-    def test_remove_hatching_if_pet_available_empty_ok(self):
+    def test_remove_hatch_item_if_pet_available_empty_ok(self):
         empty: List[Pet] = []
         egg = Egg("Wolf")
-        potion = HatchingPotion("Ghost")
+        potion = HatchPotion("Ghost")
         hatch_plan = HatchPlan().add(egg=egg, potion=potion)
 
-        hatch_plan.remove_hatching_if_pet_available(empty)
+        hatch_plan.remove_hatch_item_if_pet_available(empty)
 
         assert len(hatch_plan) == 1
         assert HatchPlanItem(egg, potion) in hatch_plan
 
-    def test_remove_hatching_if_pet_available_yes_available_ok(self):
+    def test_remove_hatch_item_if_pet_available_yes_available_ok(self):
         pets: List[Pet] = [Pet("Wolf-Ghost", feed_status=FeedStatus(5))]
         egg = Egg("Wolf")
-        potion = HatchingPotion("Ghost")
+        potion = HatchPotion("Ghost")
         hatch_plan = HatchPlan().add(egg=egg, potion=potion)
 
-        hatch_plan.remove_hatching_if_pet_available(pets)
+        hatch_plan.remove_hatch_item_if_pet_available(pets)
 
         assert len(hatch_plan) == 0
         assert HatchPlanItem(egg, potion) not in hatch_plan
 
-    def test_remove_hatching_if_pet_available_yes_and_no_available_ok(self):
+    def test_remove_hatch_item_if_pet_available_yes_and_no_available_ok(self):
         # 1. Wolf-Ghost is available, so that one should be filtered out.
         # 2. However, even though Wolf-Base is in the list, it is not available because
         #    feed status is -1.
@@ -161,13 +161,13 @@ class TestHatchPlan:
             Pet("Wolf-Base", feed_status=FeedStatus(-1))
         ]
         egg = Egg("Wolf")
-        ghost_potion = HatchingPotion("Ghost")
-        base_potion = HatchingPotion("Base")
+        ghost_potion = HatchPotion("Ghost")
+        base_potion = HatchPotion("Base")
         hatch_plan = HatchPlan() \
             .add(egg=egg, potion=ghost_potion) \
             .add(egg=egg, potion=base_potion)
 
-        hatch_plan.remove_hatching_if_pet_available(pets)
+        hatch_plan.remove_hatch_item_if_pet_available(pets)
 
         assert len(hatch_plan) == 1
         assert HatchPlanItem(egg, base_potion) in hatch_plan
@@ -175,8 +175,8 @@ class TestHatchPlan:
 
     def test__iter__(self):
         egg1, egg2 = Egg("Wolf"), Egg("Egg")
-        ghost_potion = HatchingPotion("Ghost")
-        base_potion = HatchingPotion("Base")
+        ghost_potion = HatchPotion("Ghost")
+        base_potion = HatchPotion("Base")
         hatch_plan = HatchPlan() \
             .add(egg=egg1, potion=ghost_potion) \
             .add(egg=egg2, potion=base_potion)
@@ -191,7 +191,7 @@ class TestHatchPlan:
 class TestHatchPlanMaker:
     def test__repr__(self):
         eggs = EggCollection({"Wolf": 1, "Whale": 2})
-        potions = HatchingPotionCollection({"Base": 1, "Ember": 2})
+        potions = HatchPotionCollection({"Base": 1, "Ember": 2})
         plan_maker = HatchPlanMaker(egg_collection=eggs, hatch_potion_collection=potions)
 
         result: str = repr(plan_maker)
@@ -206,7 +206,7 @@ class TestHatchPlanMaker:
 
     def test_make_plan_no_eggs(self):
         empty_eggs = EggCollection()
-        potions = HatchingPotionCollection({"Zombie": 1})
+        potions = HatchPotionCollection({"Zombie": 1})
 
         plan_maker = HatchPlanMaker(egg_collection=empty_eggs, hatch_potion_collection=potions)
 
@@ -215,9 +215,9 @@ class TestHatchPlanMaker:
         expected_empty_plan = HatchPlan()
         assert result == expected_empty_plan
 
-    def test_make_plan_no_hatching_potions(self):
+    def test_make_plan_no_hatch_potions(self):
         eggs = EggCollection({"Owl": 1})
-        empty_potions = HatchingPotionCollection()
+        empty_potions = HatchPotionCollection()
         plan_maker = HatchPlanMaker(egg_collection=eggs, hatch_potion_collection=empty_potions)
 
         result: HatchPlan = plan_maker.make_plan()
@@ -227,17 +227,17 @@ class TestHatchPlanMaker:
 
     def test_make_plan_1potion_1egg_ok(self):
         eggs = EggCollection({"Owl": 1})
-        potions = HatchingPotionCollection({"Base": 1})
+        potions = HatchPotionCollection({"Base": 1})
         plan_maker = HatchPlanMaker(egg_collection=eggs, hatch_potion_collection=potions)
 
         result: HatchPlan = plan_maker.make_plan()
 
-        expected = HatchPlan().add(egg=Egg("Owl"), potion=HatchingPotion("Base"))
+        expected = HatchPlan().add(egg=Egg("Owl"), potion=HatchPotion("Base"))
         assert result == expected
 
     def test_make_plan_1magic_potion_1quest_egg_ok(self):
         eggs = EggCollection({"Owl": 1})
-        magic_potions = HatchingPotionCollection({"Thunderstorm": 1})
+        magic_potions = HatchPotionCollection({"Thunderstorm": 1})
         plan_maker = HatchPlanMaker(egg_collection=eggs, hatch_potion_collection=magic_potions)
 
         result: HatchPlan = plan_maker.make_plan()
@@ -247,18 +247,18 @@ class TestHatchPlanMaker:
 
     def test_make_plan_1magic_potion_2normal_1quest_egg_ok(self):
         eggs = EggCollection({"Owl": 1, "Fox": 2})
-        magic_potions = HatchingPotionCollection({"Thunderstorm": 1})
+        magic_potions = HatchPotionCollection({"Thunderstorm": 1})
         plan_maker = HatchPlanMaker(egg_collection=eggs, hatch_potion_collection=magic_potions)
 
         result: HatchPlan = plan_maker.make_plan()
 
         expected = HatchPlan().add(egg=Egg("Fox"),
-                                   potion=HatchingPotion("Thunderstorm"))
+                                   potion=HatchPotion("Thunderstorm"))
         assert result == expected
 
     def test_make_plan_more_potions_than_eggs(self):
         eggs = EggCollection({"Horse": 1, "Cactus": 2})
-        potions = HatchingPotionCollection(
+        potions = HatchPotionCollection(
             {"SolarSystem": 2, "Zombie": 1, "Base": 1, "Fluorite": 1, "Shade": 3}
         )
         plan_maker = HatchPlanMaker(egg_collection=eggs, hatch_potion_collection=potions)
@@ -266,9 +266,9 @@ class TestHatchPlanMaker:
         result: HatchPlan = plan_maker.make_plan()
 
         expected = HatchPlan() \
-            .add(egg=Egg("Horse"), potion=HatchingPotion("Zombie")) \
-            .add(egg=Egg("Cactus"), potion=HatchingPotion("SolarSystem")) \
-            .add(egg=Egg("Cactus"), potion=HatchingPotion("Base")) \
+            .add(egg=Egg("Horse"), potion=HatchPotion("Zombie")) \
+            .add(egg=Egg("Cactus"), potion=HatchPotion("SolarSystem")) \
+            .add(egg=Egg("Cactus"), potion=HatchPotion("Base")) \
             # ^ Can't hatch same Cactus twice with same potion
 
         assert result == expected

--- a/src/tests/hoplalib/hatchery/test_hatchalgorithm.py
+++ b/src/tests/hoplalib/hatchery/test_hatchalgorithm.py
@@ -6,7 +6,7 @@ import pytest
 from hopla.hoplalib.hatchery.eggmodels import Egg, EggCollection
 from hopla.hoplalib.hatchery.hatchalgorithms import HatchPlan, HatchPlanItem, HatchPlanMaker
 from hopla.hoplalib.hatchery.hatchpotionmodels import HatchingPotion, HatchingPotionCollection
-from hopla.hoplalib.zoo.foodmodels import FeedingStatus
+from hopla.hoplalib.zoo.foodmodels import FeedStatus
 from hopla.hoplalib.zoo.petmodels import Pet
 
 
@@ -142,7 +142,7 @@ class TestHatchPlan:
         assert HatchPlanItem(egg, potion) in hatch_plan
 
     def test_remove_hatching_if_pet_available_yes_available_ok(self):
-        pets: List[Pet] = [Pet("Wolf-Ghost", feeding_status=FeedingStatus(5))]
+        pets: List[Pet] = [Pet("Wolf-Ghost", feeding_status=FeedStatus(5))]
         egg = Egg("Wolf")
         potion = HatchingPotion("Ghost")
         hatch_plan = HatchPlan().add(egg=egg, potion=potion)
@@ -157,8 +157,8 @@ class TestHatchPlan:
         # 2. However, even though Wolf-Base is in the list, it is not available because
         #    feedings status is -1.
         pets: List[Pet] = [
-            Pet("Wolf-Ghost", feeding_status=FeedingStatus(5)),
-            Pet("Wolf-Base", feeding_status=FeedingStatus(-1))
+            Pet("Wolf-Ghost", feeding_status=FeedStatus(5)),
+            Pet("Wolf-Base", feeding_status=FeedStatus(-1))
         ]
         egg = Egg("Wolf")
         ghost_potion = HatchingPotion("Ghost")

--- a/src/tests/hoplalib/hatchery/test_hatchcontroller.py
+++ b/src/tests/hoplalib/hatchery/test_hatchcontroller.py
@@ -12,7 +12,7 @@ class TestHatchRequester:
         ("Fox", "Polkadot")
     ])
     def test_url(self, egg_name: str, potion_name: str):
-        requester = HatchRequester(egg_name=egg_name, hatching_potion_name=potion_name)
+        requester = HatchRequester(egg_name=egg_name, hatch_potion_name=potion_name)
 
         result_url: str = requester.url
 

--- a/src/tests/hoplalib/hatchery/test_hatchpotionmodels.py
+++ b/src/tests/hoplalib/hatchery/test_hatchpotionmodels.py
@@ -5,45 +5,45 @@ import click
 import pytest
 
 from hopla.hoplalib.errors import YouFoundABugRewardError
-from hopla.hoplalib.hatchery.hatchdata import HatchingPotionData
-from hopla.hoplalib.hatchery.hatchpotionmodels import HatchingPotion, HatchingPotionCollection, \
-    HatchingPotionException
+from hopla.hoplalib.hatchery.hatchdata import HatchPotionData
+from hopla.hoplalib.hatchery.hatchpotionmodels import HatchPotion, HatchPotionCollection, \
+    HatchPotionException
 
 _SAMPLE_SIZE = 10
 
 
-class TestHatchingPotion:
+class TestHatchPotion:
     def test__init__invalid_name_fail(self):
         name = "InvalidName"
-        with pytest.raises(HatchingPotionException) as exec_info:
-            HatchingPotion(name, quantity=1)
+        with pytest.raises(HatchPotionException) as exec_info:
+            HatchPotion(name, quantity=1)
 
         assert str(exec_info.value).startswith(f"{name} is not a valid hatching potion name.")
         assert exec_info.errisinstance((YouFoundABugRewardError, click.ClickException))
 
     @pytest.mark.parametrize(
         "potion_name,quantity",
-        list(zip(random.sample(HatchingPotionData.hatching_potion_names, k=_SAMPLE_SIZE),
+        list(zip(random.sample(HatchPotionData.hatch_potion_names, k=_SAMPLE_SIZE),
                  range(-_SAMPLE_SIZE, 0)))
     )
     def test__init__invalid_quantity_fail(self, potion_name: str, quantity: int):
-        with pytest.raises(HatchingPotionException) as exec_info:
-            HatchingPotion(potion_name, quantity=quantity)
+        with pytest.raises(HatchPotionException) as exec_info:
+            HatchPotion(potion_name, quantity=quantity)
 
         assert str(exec_info.value).startswith(f"{quantity} is below 0.")
         assert exec_info.errisinstance((YouFoundABugRewardError, click.ClickException))
 
     @pytest.mark.parametrize(
         "potion_name,quantity",
-        list(zip(random.sample(HatchingPotionData.hatching_potion_names, k=_SAMPLE_SIZE),
+        list(zip(random.sample(HatchPotionData.hatch_potion_names, k=_SAMPLE_SIZE),
                  range(0, _SAMPLE_SIZE)))
     )
     def test__repr__ok(self, potion_name: str, quantity: int):
-        potion = HatchingPotion(potion_name, quantity=quantity)
+        potion = HatchPotion(potion_name, quantity=quantity)
 
         result: str = repr(potion)
 
-        assert result == f"HatchingPotion({potion_name}: {quantity})"
+        assert result == f"HatchPotion({potion_name}: {quantity})"
 
     @pytest.mark.parametrize("potion_name,quantity", [
         ("Base", 10),
@@ -51,11 +51,11 @@ class TestHatchingPotion:
         ("Golden", 0),
     ])
     def test_is_standard_potion(self, potion_name: str, quantity: int):
-        potion = HatchingPotion(potion_name, quantity=quantity)
+        potion = HatchPotion(potion_name, quantity=quantity)
 
-        assert potion.is_standard_hatching_potion() is True
-        assert potion.is_magic_hatching_potion() is False
-        assert potion.is_wacky_hatching_potion() is False
+        assert potion.is_standard_hatch_potion() is True
+        assert potion.is_magic_hatch_potion() is False
+        assert potion.is_wacky_hatch_potion() is False
 
     @pytest.mark.parametrize("potion_name,quantity", [
         ("BirchBark", 10),
@@ -67,41 +67,41 @@ class TestHatchingPotion:
         ("SolarSystem", 9001),
     ])
     def test_is_magic_potion(self, potion_name: str, quantity: int):
-        potion = HatchingPotion(potion_name, quantity=quantity)
+        potion = HatchPotion(potion_name, quantity=quantity)
 
-        assert potion.is_standard_hatching_potion() is False
-        assert potion.is_magic_hatching_potion() is True
-        assert potion.is_wacky_hatching_potion() is False
+        assert potion.is_standard_hatch_potion() is False
+        assert potion.is_magic_hatch_potion() is True
+        assert potion.is_wacky_hatch_potion() is False
 
     @pytest.mark.parametrize("potion_name,quantity", [
         ("Veggie", 10),
         ("Dessert", 0),
     ])
-    def test_is_wacky_hatching_potion(self, potion_name: str, quantity: int):
-        potion = HatchingPotion(potion_name, quantity=quantity)
+    def test_is_wacky_hatch_potion(self, potion_name: str, quantity: int):
+        potion = HatchPotion(potion_name, quantity=quantity)
 
-        assert potion.is_standard_hatching_potion() is False
-        assert potion.is_magic_hatching_potion() is False
-        assert potion.is_wacky_hatching_potion() is True
+        assert potion.is_standard_hatch_potion() is False
+        assert potion.is_magic_hatch_potion() is False
+        assert potion.is_wacky_hatch_potion() is True
 
 
-class TestHatchingPotionCollection:
+class TestHatchPotionCollection:
     def test__init__empty_ok(self):
-        collection = HatchingPotionCollection()
-        assert collection == HatchingPotionCollection({})
+        collection = HatchPotionCollection()
+        assert collection == HatchPotionCollection({})
         assert len(collection) == 0
 
     def test__init__ok(self):
         potion_dict = {"Base": 0, "Moonglow": 42, "Sunset": 2}
 
-        collection = HatchingPotionCollection(potion_dict)
+        collection = HatchPotionCollection(potion_dict)
 
-        assert collection["Base"] == HatchingPotion("Base", quantity=0)
-        assert collection["Moonglow"] == HatchingPotion("Moonglow", quantity=42)
-        assert collection["Sunset"] == HatchingPotion("Sunset", quantity=2)
+        assert collection["Base"] == HatchPotion("Base", quantity=0)
+        assert collection["Moonglow"] == HatchPotion("Moonglow", quantity=42)
+        assert collection["Sunset"] == HatchPotion("Sunset", quantity=2)
 
     def test__iter__ok(self):
-        collection = HatchingPotionCollection({"Base": 1, "Moonglow": 42, "Sunset": 2})
+        collection = HatchPotionCollection({"Base": 1, "Moonglow": 42, "Sunset": 2})
 
         iterator = iter(collection)
 
@@ -112,39 +112,39 @@ class TestHatchingPotionCollection:
             next(iterator)
 
     def test__getitem__ok(self):
-        collection = HatchingPotionCollection({"Base": 1, "Moonglow": 42, "Sunset": 0})
+        collection = HatchPotionCollection({"Base": 1, "Moonglow": 42, "Sunset": 0})
 
-        assert collection["Base"] == HatchingPotion("Base", quantity=1)
-        assert collection["Moonglow"] == HatchingPotion("Moonglow", quantity=42)
-        assert collection["Sunset"] == HatchingPotion("Sunset", quantity=0)
+        assert collection["Base"] == HatchPotion("Base", quantity=1)
+        assert collection["Moonglow"] == HatchPotion("Moonglow", quantity=42)
+        assert collection["Sunset"] == HatchPotion("Sunset", quantity=0)
 
-    def test_remove_hatching_potion_ok(self):
+    def test_remove_hatch_potion_ok(self):
         potion1_quantity = 3
         potion2_quantity = 42
         potion3_name, potion3_quantity = "Sunset", 1
-        collection = HatchingPotionCollection({
+        collection = HatchPotionCollection({
             "Base": potion1_quantity,
             "Moonglow": potion2_quantity,
             potion3_name: potion3_quantity
         })
 
-        collection.remove_hatching_potion(HatchingPotion("Base"))
-        collection.remove_hatching_potion(HatchingPotion("Moonglow"))
-        collection.remove_hatching_potion(HatchingPotion(potion3_name))
+        collection.remove_hatch_potion(HatchPotion("Base"))
+        collection.remove_hatch_potion(HatchPotion("Moonglow"))
+        collection.remove_hatch_potion(HatchPotion(potion3_name))
 
-        assert collection["Base"] == HatchingPotion("Base",
-                                                    quantity=potion1_quantity - 1)
-        assert collection["Moonglow"] == HatchingPotion("Moonglow",
-                                                        quantity=potion2_quantity - 1)
-        assert collection[potion3_name] == HatchingPotion(potion3_name,
-                                                          quantity=potion3_quantity - 1)
+        assert collection["Base"] == HatchPotion("Base",
+                                                 quantity=potion1_quantity - 1)
+        assert collection["Moonglow"] == HatchPotion("Moonglow",
+                                                     quantity=potion2_quantity - 1)
+        assert collection[potion3_name] == HatchPotion(potion3_name,
+                                                       quantity=potion3_quantity - 1)
 
-    def test_remove_hatching_potion_not_available_faile(self):
-        collection = HatchingPotionCollection({"Base": 1})
+    def test_remove_hatch_potion_not_available_faile(self):
+        collection = HatchPotionCollection({"Base": 1})
 
         not_found_potion_name = "Moonglow"
-        with pytest.raises(HatchingPotionException) as exec_info:
-            collection.remove_hatching_potion(HatchingPotion(not_found_potion_name))
+        with pytest.raises(HatchPotionException) as exec_info:
+            collection.remove_hatch_potion(HatchPotion(not_found_potion_name))
 
         expected_msg = f"{not_found_potion_name} was not in the collection "
         assert str(exec_info.value).startswith(expected_msg)

--- a/src/tests/hoplalib/user/test_usermodels.py
+++ b/src/tests/hoplalib/user/test_usermodels.py
@@ -80,10 +80,10 @@ class TestHabiticaUser:
         user = HabiticaUser(user_dict={"items": {"food": food}})
         assert user.get_food() == food
 
-    def test_get_hatching_potions(self):
-        hatching_potions = {"Base": 10, "SolarSystem": 1009}
-        user = HabiticaUser(user_dict={"items": {"hatchingPotions": hatching_potions}})
-        assert user.get_hatching_potions() == hatching_potions
+    def test_get_hatch_potions(self):
+        hatch_potions = {"Base": 10, "SolarSystem": 1009}
+        user = HabiticaUser(user_dict={"items": {"hatchingPotions": hatch_potions}})
+        assert user.get_hatch_potions() == hatch_potions
 
     def test_get_eggs(self):
         eggs = {"Fox": 1001, "Nudibranch": 9}

--- a/src/tests/hoplalib/zoo/test_foodmodels.py
+++ b/src/tests/hoplalib/zoo/test_foodmodels.py
@@ -4,13 +4,13 @@ import pytest
 
 from hopla.cli.groupcmds.get_user import HabiticaUser
 from hopla.hoplalib.zoo.foodmodels import FeedStatus, Food, FoodException, FoodStockpile, \
-    FoodStockpileBuilder, InvalidFeedingStatus
+    FoodStockpileBuilder, InvalidFeedStatus
 
 
-class TestFeedingStatus:
-    valid_feeding_range = [-1, 0, *range(5, 50)]
+class TestFeedStatus:
+    valid_feed_range = [-1, 0, *range(5, 50)]
 
-    @pytest.mark.parametrize("valid_status", valid_feeding_range)
+    @pytest.mark.parametrize("valid_status", valid_feed_range)
     def test__init__ok(self, valid_status: int):
         status = FeedStatus(valid_status)
         assert int(status) == valid_status
@@ -19,37 +19,37 @@ class TestFeedingStatus:
         *range(-10, -1), *range(1, 5), *range(50, 60)
     ])
     def test__init__fail(self, invalid_status: int):
-        with pytest.raises(InvalidFeedingStatus) as exec_info:
+        with pytest.raises(InvalidFeedStatus) as exec_info:
             FeedStatus(invalid_status)
 
         er_msg = str(exec_info.value)
         assert f"{invalid_status} is invalid" in er_msg
 
-    @pytest.mark.parametrize("valid_status", valid_feeding_range)
+    @pytest.mark.parametrize("valid_status", valid_feed_range)
     def test__repr__ok(self, valid_status: int):
         result: str = repr(FeedStatus(valid_status))
         assert result == f"FeedStatus({valid_status})"
 
     @pytest.mark.parametrize(
-        "feeding_status,expected_percentage",
+        "feed_status,expected_percentage",
         [(-1, 100), (0, 0), (5, 10), (7, 14), (48, 96)]
     )
-    def test_to_percentage_ok(self, feeding_status: int,
+    def test_to_percentage_ok(self, feed_status: int,
                               expected_percentage: int):
-        feeding_status = FeedStatus(feeding_status)
+        feed_status = FeedStatus(feed_status)
 
-        result_percentage = feeding_status.to_percentage()
+        result_percentage = feed_status.to_percentage()
 
         assert result_percentage == expected_percentage
 
     @pytest.mark.parametrize(
-        "feeding_status,expected_available", [
+        "feed_status,expected_available", [
             (-1, False), (0, False), (5, True), (27, True), (42, True)
         ]
     )
-    def test_is_pet_available(self, feeding_status: int,
+    def test_is_pet_available(self, feed_status: int,
                               expected_available: bool):
-        status = FeedStatus(feeding_status)
+        status = FeedStatus(feed_status)
 
         result: bool = status.is_pet_available()
 
@@ -67,10 +67,10 @@ class TestFeedingStatus:
     def test_required_food_items_to_become_mount_favorite(self,
                                                           start_status: int,
                                                           expected_food_items: int):
-        feeding_status = FeedStatus(start_status)
+        feed_status = FeedStatus(start_status)
 
         is_favorite = True
-        result = feeding_status.required_food_items_to_become_mount(is_favorite)
+        result = feed_status.required_food_items_to_become_mount(is_favorite)
 
         assert result == expected_food_items
 
@@ -88,38 +88,38 @@ class TestFeedingStatus:
     def test_required_food_items_to_become_mount_not_favorite(self,
                                                               start_status: int,
                                                               expected_food_items: int):
-        feeding_status = FeedStatus(start_status)
+        feed_status = FeedStatus(start_status)
 
         is_favorite = False
-        result = feeding_status.required_food_items_to_become_mount(is_favorite)
+        result = feed_status.required_food_items_to_become_mount(is_favorite)
 
         assert result == expected_food_items
 
 
-class TestFeedingStatusHash:
-    _feeding_statuses = [
+class TestFeedStatusHash:
+    _feed_statuses = [
         FeedStatus(-1), FeedStatus(), FeedStatus(5),
         FeedStatus(20), FeedStatus(35), FeedStatus(49)
     ]
 
-    @pytest.mark.parametrize("feeding_status", _feeding_statuses)
-    def test__hash__same_object(self, feeding_status: FeedStatus):
+    @pytest.mark.parametrize("feed_status", _feed_statuses)
+    def test__hash__same_object(self, feed_status: FeedStatus):
         # A minimal requirement for __hash__ is that if 2 FeedStatus objects are
         # identical, they MUST have the same hash.
-        assert hash(feeding_status) == hash(feeding_status)
+        assert hash(feed_status) == hash(feed_status)
 
     @pytest.mark.parametrize(
-        "feeding_status,equal_feeding_status",
-        list(zip(_feeding_statuses + [FeedStatus()],
-                 _feeding_statuses + [FeedStatus(5)]))
+        "feed_status,equal_feed_status",
+        list(zip(_feed_statuses + [FeedStatus()],
+                 _feed_statuses + [FeedStatus(5)]))
     )
     def test__hash__same_valued_object(self,
-                                       feeding_status: FeedStatus,
-                                       equal_feeding_status: FeedStatus):
+                                       feed_status: FeedStatus,
+                                       equal_feed_status: FeedStatus):
         # A minimal requirement for __hash__ if 2 FeedStatus objects
         # are equal (__eq__) , they MUST have the same hash.
-        assert feeding_status == equal_feeding_status
-        assert hash(feeding_status) == hash(equal_feeding_status)
+        assert feed_status == equal_feed_status
+        assert hash(feed_status) == hash(equal_feed_status)
 
 
 class TestFood:

--- a/src/tests/hoplalib/zoo/test_foodmodels.py
+++ b/src/tests/hoplalib/zoo/test_foodmodels.py
@@ -3,7 +3,7 @@ from typing import Dict
 import pytest
 
 from hopla.cli.groupcmds.get_user import HabiticaUser
-from hopla.hoplalib.zoo.foodmodels import FeedingStatus, Food, FoodException, FoodStockpile, \
+from hopla.hoplalib.zoo.foodmodels import FeedStatus, Food, FoodException, FoodStockpile, \
     FoodStockpileBuilder, InvalidFeedingStatus
 
 
@@ -12,7 +12,7 @@ class TestFeedingStatus:
 
     @pytest.mark.parametrize("valid_status", valid_feeding_range)
     def test__init__ok(self, valid_status: int):
-        status = FeedingStatus(valid_status)
+        status = FeedStatus(valid_status)
         assert int(status) == valid_status
 
     @pytest.mark.parametrize("invalid_status", [
@@ -20,15 +20,15 @@ class TestFeedingStatus:
     ])
     def test__init__fail(self, invalid_status: int):
         with pytest.raises(InvalidFeedingStatus) as exec_info:
-            FeedingStatus(invalid_status)
+            FeedStatus(invalid_status)
 
         er_msg = str(exec_info.value)
         assert f"{invalid_status} is invalid" in er_msg
 
     @pytest.mark.parametrize("valid_status", valid_feeding_range)
     def test__repr__ok(self, valid_status: int):
-        result: str = repr(FeedingStatus(valid_status))
-        assert result == f"FeedingStatus({valid_status})"
+        result: str = repr(FeedStatus(valid_status))
+        assert result == f"FeedStatus({valid_status})"
 
     @pytest.mark.parametrize(
         "feeding_status,expected_percentage",
@@ -36,7 +36,7 @@ class TestFeedingStatus:
     )
     def test_to_percentage_ok(self, feeding_status: int,
                               expected_percentage: int):
-        feeding_status = FeedingStatus(feeding_status)
+        feeding_status = FeedStatus(feeding_status)
 
         result_percentage = feeding_status.to_percentage()
 
@@ -49,7 +49,7 @@ class TestFeedingStatus:
     )
     def test_is_pet_available(self, feeding_status: int,
                               expected_available: bool):
-        status = FeedingStatus(feeding_status)
+        status = FeedStatus(feeding_status)
 
         result: bool = status.is_pet_available()
 
@@ -67,7 +67,7 @@ class TestFeedingStatus:
     def test_required_food_items_to_become_mount_favorite(self,
                                                           start_status: int,
                                                           expected_food_items: int):
-        feeding_status = FeedingStatus(start_status)
+        feeding_status = FeedStatus(start_status)
 
         is_favorite = True
         result = feeding_status.required_food_items_to_become_mount(is_favorite)
@@ -88,7 +88,7 @@ class TestFeedingStatus:
     def test_required_food_items_to_become_mount_not_favorite(self,
                                                               start_status: int,
                                                               expected_food_items: int):
-        feeding_status = FeedingStatus(start_status)
+        feeding_status = FeedStatus(start_status)
 
         is_favorite = False
         result = feeding_status.required_food_items_to_become_mount(is_favorite)
@@ -98,25 +98,25 @@ class TestFeedingStatus:
 
 class TestFeedingStatusHash:
     _feeding_statuses = [
-        FeedingStatus(-1), FeedingStatus(), FeedingStatus(5),
-        FeedingStatus(20), FeedingStatus(35), FeedingStatus(49)
+        FeedStatus(-1), FeedStatus(), FeedStatus(5),
+        FeedStatus(20), FeedStatus(35), FeedStatus(49)
     ]
 
     @pytest.mark.parametrize("feeding_status", _feeding_statuses)
-    def test__hash__same_object(self, feeding_status: FeedingStatus):
-        # A minimal requirement for __hash__ is that if 2 FeedingStatus objects are
+    def test__hash__same_object(self, feeding_status: FeedStatus):
+        # A minimal requirement for __hash__ is that if 2 FeedStatus objects are
         # identical, they MUST have the same hash.
         assert hash(feeding_status) == hash(feeding_status)
 
     @pytest.mark.parametrize(
         "feeding_status,equal_feeding_status",
-        list(zip(_feeding_statuses + [FeedingStatus()],
-                 _feeding_statuses + [FeedingStatus(5)]))
+        list(zip(_feeding_statuses + [FeedStatus()],
+                 _feeding_statuses + [FeedStatus(5)]))
     )
     def test__hash__same_valued_object(self,
-                                       feeding_status: FeedingStatus,
-                                       equal_feeding_status: FeedingStatus):
-        # A minimal requirement for __hash__ if 2 FeedingStatus objects
+                                       feeding_status: FeedStatus,
+                                       equal_feeding_status: FeedStatus):
+        # A minimal requirement for __hash__ if 2 FeedStatus objects
         # are equal (__eq__) , they MUST have the same hash.
         assert feeding_status == equal_feeding_status
         assert hash(feeding_status) == hash(equal_feeding_status)

--- a/src/tests/hoplalib/zoo/test_petcontroller.py
+++ b/src/tests/hoplalib/zoo/test_petcontroller.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from hopla.hoplalib.zoo.petcontroller import FeedPostRequester
-from hopla.hoplalib.zoo.zoofeeding_algorithms import FeedPlanItem
+from hopla.hoplalib.zoo.zoofeed_algorithms import FeedPlanItem
 
 
 class TestFeedPostRequester:

--- a/src/tests/hoplalib/zoo/test_petmodels.py
+++ b/src/tests/hoplalib/zoo/test_petmodels.py
@@ -8,7 +8,7 @@ from click import ClickException
 from hopla.hoplalib.common import GlobalConstants
 from hopla.hoplalib.errors import YouFoundABugRewardError
 from hopla.hoplalib.zoo.fooddata import FoodData
-from hopla.hoplalib.zoo.foodmodels import FeedingStatus, InvalidFeedingStatus
+from hopla.hoplalib.zoo.foodmodels import FeedStatus, InvalidFeedingStatus
 from hopla.hoplalib.zoo.petdata import PetData
 from hopla.hoplalib.zoo.petmodels import InvalidPet, InvalidPetMountPair, Mount, Pet, PetMountPair
 
@@ -44,7 +44,7 @@ class TestPet:
         )
         def test_init_raises_invalid_feeding_status_fail(self, invalid_feed_status: int):
             with pytest.raises(InvalidFeedingStatus) as execinfo:
-                feeding_status = FeedingStatus(invalid_feed_status)
+                feeding_status = FeedStatus(invalid_feed_status)
                 Pet("PandaCub-IcySnow", feeding_status=feeding_status)
 
             err_msg = str(execinfo.value)
@@ -55,7 +55,7 @@ class TestPet:
             [5, 10, 20, -1, 49]
         )
         def test_init_sets_valid_feeding_status_ok(self, valid_feed_status: int):
-            feeding_status = FeedingStatus(valid_feed_status)
+            feeding_status = FeedStatus(valid_feed_status)
             pet = Pet("LionCub-Sunset", feeding_status=feeding_status)
 
             assert valid_feed_status == int(pet.feeding_status)
@@ -175,7 +175,7 @@ class TestPet:
 
         def test___repr__(self):
             pet_name = "Fox-Shadow"
-            feeding_status = FeedingStatus(10)
+            feeding_status = FeedStatus(10)
             pet = Pet(pet_name, feeding_status=feeding_status)
 
             result = str(pet)
@@ -193,7 +193,7 @@ class TestPet:
         )
         def test_feeding_status_explanation_ok(self, feeding_status: int,
                                                partial_expected_message: str):
-            feeding_status = FeedingStatus(feeding_status)
+            feeding_status = FeedStatus(feeding_status)
             pet = Pet(TestPet.TestOtherPetFunctions.PET_NAME, feeding_status=feeding_status)
 
             result_explanation: str = pet.feeding_status_explanation()
@@ -327,13 +327,13 @@ class TestPet:
 
         @pytest.mark.parametrize(
             "pet,food_name,expected_times", [
-                (Pet("Hedgehog-Shade", feeding_status=FeedingStatus(10)), "Chocolate", 8),
-                (Pet("Hedgehog-Shade", feeding_status=FeedingStatus(10)), "Milk", 20),
+                (Pet("Hedgehog-Shade", feeding_status=FeedStatus(10)), "Chocolate", 8),
+                (Pet("Hedgehog-Shade", feeding_status=FeedStatus(10)), "Milk", 20),
                 (Pet("Egg-Base"), "Meat", 9),
                 (Pet("Egg-Zombie"), "CottonCandyPink", 23),
-                (Pet("Egg-Base", feeding_status=FeedingStatus(40)), "Meat", 2),
-                (Pet("Egg-Base", feeding_status=FeedingStatus(44)), "Meat", 2),
-                (Pet("Egg-Golden", feeding_status=FeedingStatus(47)), "Fish", 2),
+                (Pet("Egg-Base", feeding_status=FeedStatus(40)), "Meat", 2),
+                (Pet("Egg-Base", feeding_status=FeedStatus(44)), "Meat", 2),
+                (Pet("Egg-Golden", feeding_status=FeedStatus(47)), "Fish", 2),
             ]
         )
         def test_required_food_items_until_mount(self, pet: Pet,
@@ -368,7 +368,7 @@ class TestMount:
 class TestPetMountPair:
     empty_pair = PetMountPair(pet=None, mount=None)
 
-    phoenix_pet_only_pair = PetMountPair(pet=Pet("Phoenix-Base", feeding_status=FeedingStatus(5)),
+    phoenix_pet_only_pair = PetMountPair(pet=Pet("Phoenix-Base", feeding_status=FeedStatus(5)),
                                          mount=None)
 
     phoenix_mount_only_pair = PetMountPair(pet=None,
@@ -376,10 +376,10 @@ class TestPetMountPair:
 
     mount_available_pairs: List[PetMountPair] = [
         # only mount
-        PetMountPair(pet=Pet("Owl-Shade", feeding_status=FeedingStatus(-1)),
+        PetMountPair(pet=Pet("Owl-Shade", feeding_status=FeedStatus(-1)),
                      mount=Mount("Owl-Shade", availability_status=True)),
         # pet is there, and mount as well
-        PetMountPair(pet=Pet("Egg-White", feeding_status=FeedingStatus(5)),
+        PetMountPair(pet=Pet("Egg-White", feeding_status=FeedStatus(5)),
                      mount=Mount("Egg-White", availability_status=True)),
         phoenix_mount_only_pair
     ]
@@ -390,7 +390,7 @@ class TestPetMountPair:
         # cannot feed pet if there is a mount
         *mount_available_pairs,
         # released pet
-        PetMountPair(pet=Pet("Wolf-Base", feeding_status=FeedingStatus(0)),
+        PetMountPair(pet=Pet("Wolf-Base", feeding_status=FeedStatus(0)),
                      mount=None),
         # unfeedable pet
         phoenix_pet_only_pair,
@@ -400,10 +400,10 @@ class TestPetMountPair:
 
     feedable_pairs: List[PetMountPair] = [
         # only pet
-        PetMountPair(pet=Pet("Rat-CottonCandyBlue", feeding_status=FeedingStatus(10)),
+        PetMountPair(pet=Pet("Rat-CottonCandyBlue", feeding_status=FeedStatus(10)),
                      mount=None),
         # mount was released
-        PetMountPair(pet=Pet("Rat-CottonCandyPink", feeding_status=FeedingStatus(5)),
+        PetMountPair(pet=Pet("Rat-CottonCandyPink", feeding_status=FeedStatus(5)),
                      mount=Mount("Rat-CottonCandyPink", availability_status=None)),
     ]
 

--- a/src/tests/hoplalib/zoo/test_petmodels.py
+++ b/src/tests/hoplalib/zoo/test_petmodels.py
@@ -155,10 +155,10 @@ class TestPet:
                 ("Hippo-Golden", "CottonCandyBlue", False),
             ]
         )
-        def test_is_favorite_food_for_hatching_pets(self,
-                                                    pet_name: str,
-                                                    food_name: str,
-                                                    expected_result: bool):
+        def test_is_favorite_food_for_hatch_pets(self,
+                                                 pet_name: str,
+                                                 food_name: str,
+                                                 expected_result: bool):
             pet = Pet(pet_name)
             result = pet.is_favorite_food(food_name)
             assert result is expected_result
@@ -262,7 +262,7 @@ class TestPet:
             assert result is likes_all_food_expected
 
         @pytest.mark.parametrize(
-            "pet_name,expected_from_drop_hatching_potion", [
+            "pet_name,expected_from_drop_hatch_potion", [
                 ("Fox-Golden", True),
                 ("Dragon-Shade", True),
                 ("LionCub-Holly", False),
@@ -277,13 +277,13 @@ class TestPet:
                 ("Gryphon-Gryphatrice", False),
             ]
         )
-        def test_is_from_drop_hatching_potion(self, pet_name: str,
-                                              expected_from_drop_hatching_potion: bool):
+        def test_is_from_drop_hatch_potion(self, pet_name: str,
+                                           expected_from_drop_hatch_potion: bool):
             pet = Pet(pet_name)
 
-            result = pet.is_from_drop_hatching_potions()
+            result = pet.is_from_drop_hatch_potions()
 
-            assert result is expected_from_drop_hatching_potion
+            assert result is expected_from_drop_hatch_potion
 
         @pytest.mark.parametrize(
             "pet_name", random.sample(PetData.quest_pet_names, k=_SAMPLE_SIZE)
@@ -305,9 +305,9 @@ class TestPet:
             "pet_name",
             random.sample(PetData.magic_potion_pet_names, k=_SAMPLE_SIZE)
         )
-        def test_is_magic_hatching_potion_true(self, pet_name: str):
+        def test_is_magic_hatch_potion_true(self, pet_name: str):
             pet = Pet(pet_name)
-            assert pet.is_magic_hatching_pet() is True
+            assert pet.is_magic_hatch_pet() is True
 
         @pytest.mark.parametrize(
             "pet_name",
@@ -315,9 +315,9 @@ class TestPet:
                           PetData.quest_pet_names,
                           k=_SAMPLE_SIZE)
         )
-        def test_is_magic_hatching_potion_false(self, pet_name: str):
+        def test_is_magic_hatch_potion_false(self, pet_name: str):
             pet = Pet(pet_name)
-            assert pet.is_magic_hatching_pet() is False
+            assert pet.is_magic_hatch_pet() is False
 
         @pytest.mark.parametrize(
             "pet,food_name,expected_times", [

--- a/src/tests/hoplalib/zoo/test_petmodels.py
+++ b/src/tests/hoplalib/zoo/test_petmodels.py
@@ -8,7 +8,7 @@ from click import ClickException
 from hopla.hoplalib.common import GlobalConstants
 from hopla.hoplalib.errors import YouFoundABugRewardError
 from hopla.hoplalib.zoo.fooddata import FoodData
-from hopla.hoplalib.zoo.foodmodels import FeedStatus, InvalidFeedingStatus
+from hopla.hoplalib.zoo.foodmodels import FeedStatus, InvalidFeedStatus
 from hopla.hoplalib.zoo.petdata import PetData
 from hopla.hoplalib.zoo.petmodels import InvalidPet, InvalidPetMountPair, Mount, Pet, PetMountPair
 
@@ -38,27 +38,21 @@ class TestPet:
             pet = Pet(pet_name=pet_name)
             assert pet.pet_name == pet_name
 
-        @pytest.mark.parametrize(
-            "invalid_feed_status",
-            [-10, -2, 1, 3, 51, 100]
-        )
-        def test_init_raises_invalid_feeding_status_fail(self, invalid_feed_status: int):
-            with pytest.raises(InvalidFeedingStatus) as execinfo:
-                feeding_status = FeedStatus(invalid_feed_status)
-                Pet("PandaCub-IcySnow", feeding_status=feeding_status)
+        @pytest.mark.parametrize("invalid_feed_status", [-10, -2, 1, 3, 51, 100])
+        def test_init_raises_invalid_feed_status_fail(self, invalid_feed_status: int):
+            with pytest.raises(InvalidFeedStatus) as execinfo:
+                feed_status = FeedStatus(invalid_feed_status)
+                Pet("PandaCub-IcySnow", feed_status=feed_status)
 
             err_msg = str(execinfo.value)
-            assert f"feeding_status={int(invalid_feed_status)}" in err_msg
+            assert f"feed_status={int(invalid_feed_status)}" in err_msg
 
-        @pytest.mark.parametrize(
-            "valid_feed_status",
-            [5, 10, 20, -1, 49]
-        )
-        def test_init_sets_valid_feeding_status_ok(self, valid_feed_status: int):
-            feeding_status = FeedStatus(valid_feed_status)
-            pet = Pet("LionCub-Sunset", feeding_status=feeding_status)
+        @pytest.mark.parametrize("valid_feed_status", [5, 10, 20, -1, 49])
+        def test_init_sets_valid_feed_status_ok(self, valid_feed_status: int):
+            feed_status = FeedStatus(valid_feed_status)
+            pet = Pet("LionCub-Sunset", feed_status=feed_status)
 
-            assert valid_feed_status == int(pet.feeding_status)
+            assert valid_feed_status == int(pet.feed_status)
 
     class TestFavoriteFood:
         @pytest.mark.parametrize(
@@ -175,28 +169,28 @@ class TestPet:
 
         def test___repr__(self):
             pet_name = "Fox-Shadow"
-            feeding_status = FeedStatus(10)
-            pet = Pet(pet_name, feeding_status=feeding_status)
+            feed_status = FeedStatus(10)
+            pet = Pet(pet_name, feed_status=feed_status)
 
             result = str(pet)
 
-            expected = f"Pet({pet_name}: {feeding_status})"
+            expected = f"Pet({pet_name}: {feed_status})"
             assert result == expected
 
         @pytest.mark.parametrize(
-            "feeding_status,partial_expected_message", [
+            "feed_status,partial_expected_message", [
                 (-1, f"can't feed self.pet_name='{PET_NAME}' you only have the mount"),
                 (0, f"You released {PET_NAME}, so you cannot feed it"),
                 (5, f"Cannot determine if self.pet_name='{PET_NAME}' can be fed"),
                 (20, f"pet_name='{PET_NAME}' can be fed")
             ]
         )
-        def test_feeding_status_explanation_ok(self, feeding_status: int,
-                                               partial_expected_message: str):
-            feeding_status = FeedStatus(feeding_status)
-            pet = Pet(TestPet.TestOtherPetFunctions.PET_NAME, feeding_status=feeding_status)
+        def test_feed_status_explanation_ok(self, feed_status: int,
+                                            partial_expected_message: str):
+            feed_status = FeedStatus(feed_status)
+            pet = Pet(TestPet.TestOtherPetFunctions.PET_NAME, feed_status=feed_status)
 
-            result_explanation: str = pet.feeding_status_explanation()
+            result_explanation: str = pet.feed_status_explanation()
 
             assert partial_expected_message in result_explanation
 
@@ -208,10 +202,10 @@ class TestPet:
                 "Fox-Veggie", "Fox-Dessert",
             ]
         )
-        def test_feeding_status_unfeedable_pet(self, unfeedable_pet_name: str):
+        def test_feed_status_unfeedable_pet(self, unfeedable_pet_name: str):
             pet = Pet(unfeedable_pet_name)
 
-            result_explanation: str = pet.feeding_status_explanation()
+            result_explanation: str = pet.feed_status_explanation()
 
             assert f"{pet.pet_name} is an unfeedable pet." == result_explanation
 
@@ -327,13 +321,13 @@ class TestPet:
 
         @pytest.mark.parametrize(
             "pet,food_name,expected_times", [
-                (Pet("Hedgehog-Shade", feeding_status=FeedStatus(10)), "Chocolate", 8),
-                (Pet("Hedgehog-Shade", feeding_status=FeedStatus(10)), "Milk", 20),
+                (Pet("Hedgehog-Shade", feed_status=FeedStatus(10)), "Chocolate", 8),
+                (Pet("Hedgehog-Shade", feed_status=FeedStatus(10)), "Milk", 20),
                 (Pet("Egg-Base"), "Meat", 9),
                 (Pet("Egg-Zombie"), "CottonCandyPink", 23),
-                (Pet("Egg-Base", feeding_status=FeedStatus(40)), "Meat", 2),
-                (Pet("Egg-Base", feeding_status=FeedStatus(44)), "Meat", 2),
-                (Pet("Egg-Golden", feeding_status=FeedStatus(47)), "Fish", 2),
+                (Pet("Egg-Base", feed_status=FeedStatus(40)), "Meat", 2),
+                (Pet("Egg-Base", feed_status=FeedStatus(44)), "Meat", 2),
+                (Pet("Egg-Golden", feed_status=FeedStatus(47)), "Fish", 2),
             ]
         )
         def test_required_food_items_until_mount(self, pet: Pet,
@@ -368,7 +362,7 @@ class TestMount:
 class TestPetMountPair:
     empty_pair = PetMountPair(pet=None, mount=None)
 
-    phoenix_pet_only_pair = PetMountPair(pet=Pet("Phoenix-Base", feeding_status=FeedStatus(5)),
+    phoenix_pet_only_pair = PetMountPair(pet=Pet("Phoenix-Base", feed_status=FeedStatus(5)),
                                          mount=None)
 
     phoenix_mount_only_pair = PetMountPair(pet=None,
@@ -376,10 +370,10 @@ class TestPetMountPair:
 
     mount_available_pairs: List[PetMountPair] = [
         # only mount
-        PetMountPair(pet=Pet("Owl-Shade", feeding_status=FeedStatus(-1)),
+        PetMountPair(pet=Pet("Owl-Shade", feed_status=FeedStatus(-1)),
                      mount=Mount("Owl-Shade", availability_status=True)),
         # pet is there, and mount as well
-        PetMountPair(pet=Pet("Egg-White", feeding_status=FeedStatus(5)),
+        PetMountPair(pet=Pet("Egg-White", feed_status=FeedStatus(5)),
                      mount=Mount("Egg-White", availability_status=True)),
         phoenix_mount_only_pair
     ]
@@ -390,7 +384,7 @@ class TestPetMountPair:
         # cannot feed pet if there is a mount
         *mount_available_pairs,
         # released pet
-        PetMountPair(pet=Pet("Wolf-Base", feeding_status=FeedStatus(0)),
+        PetMountPair(pet=Pet("Wolf-Base", feed_status=FeedStatus(0)),
                      mount=None),
         # unfeedable pet
         phoenix_pet_only_pair,
@@ -400,10 +394,10 @@ class TestPetMountPair:
 
     feedable_pairs: List[PetMountPair] = [
         # only pet
-        PetMountPair(pet=Pet("Rat-CottonCandyBlue", feeding_status=FeedStatus(10)),
+        PetMountPair(pet=Pet("Rat-CottonCandyBlue", feed_status=FeedStatus(10)),
                      mount=None),
         # mount was released
-        PetMountPair(pet=Pet("Rat-CottonCandyPink", feeding_status=FeedStatus(5)),
+        PetMountPair(pet=Pet("Rat-CottonCandyPink", feed_status=FeedStatus(5)),
                      mount=Mount("Rat-CottonCandyPink", availability_status=None)),
     ]
 
@@ -414,7 +408,7 @@ class TestPetMountPair:
 
         if pet is not None:
             assert pet.pet_name is not None
-            assert pet.feeding_status is not None
+            assert pet.feed_status is not None
 
         if mount is not None:
             assert mount.mount_name is not None

--- a/src/tests/hoplalib/zoo/test_petmodels.py
+++ b/src/tests/hoplalib/zoo/test_petmodels.py
@@ -36,7 +36,7 @@ class TestPet:
         )
         def test_init_valid_pet_name_ok(self, pet_name: str):
             pet = Pet(pet_name=pet_name)
-            assert pet.pet_name == pet_name
+            assert pet.name == pet_name
 
         @pytest.mark.parametrize("invalid_feed_status", [-10, -2, 1, 3, 51, 100])
         def test_init_raises_invalid_feed_status_fail(self, invalid_feed_status: int):
@@ -179,10 +179,10 @@ class TestPet:
 
         @pytest.mark.parametrize(
             "feed_status,partial_expected_message", [
-                (-1, f"can't feed self.pet_name='{PET_NAME}' you only have the mount"),
+                (-1, f"can't feed self.name='{PET_NAME}' you only have the mount"),
                 (0, f"You released {PET_NAME}, so you cannot feed it"),
-                (5, f"Cannot determine if self.pet_name='{PET_NAME}' can be fed"),
-                (20, f"pet_name='{PET_NAME}' can be fed")
+                (5, f"Cannot determine if self.name='{PET_NAME}' can be fed"),
+                (20, f"name='{PET_NAME}' can be fed")
             ]
         )
         def test_feed_status_explanation_ok(self, feed_status: int,
@@ -207,7 +207,7 @@ class TestPet:
 
             result_explanation: str = pet.feed_status_explanation()
 
-            assert f"{pet.pet_name} is an unfeedable pet." == result_explanation
+            assert f"{pet.name} is an unfeedable pet." == result_explanation
 
         @pytest.mark.parametrize(
             "pet_name,is_gen1_expected", [
@@ -407,7 +407,7 @@ class TestPetMountPair:
         mount: Mount = pair.mount
 
         if pet is not None:
-            assert pet.pet_name is not None
+            assert pet.name is not None
             assert pet.feed_status is not None
 
         if mount is not None:

--- a/src/tests/hoplalib/zoo/test_petmodels.py
+++ b/src/tests/hoplalib/zoo/test_petmodels.py
@@ -411,7 +411,7 @@ class TestPetMountPair:
             assert pet.feed_status is not None
 
         if mount is not None:
-            assert mount.mount_name is not None
+            assert mount.name is not None
             assert mount.is_available() in [True, False, None]
 
     def test__init__pet_mount_diff_names_fail(self):

--- a/src/tests/hoplalib/zoo/test_zoofeeding_algorithms.py
+++ b/src/tests/hoplalib/zoo/test_zoofeeding_algorithms.py
@@ -5,7 +5,7 @@ from hopla.cli.groupcmds.get_user import HabiticaUser
 from hopla.hoplalib.zoo.fooddata import FoodData
 from hopla.hoplalib.zoo.foodmodels import FoodStockpile, FoodStockpileBuilder
 from hopla.hoplalib.zoo.zoomodels import Zoo, ZooBuilder
-from hopla.hoplalib.zoo.zoofeeding_algorithms import FeedPlanItem, ZooFeedingAlgorithm, \
+from hopla.hoplalib.zoo.zoofeed_algorithms import FeedPlanItem, ZooFeedAlgorithm, \
     ZookeeperFeedPlan
 from tests.testutils.user_test_utils import UserTestUtil
 
@@ -84,27 +84,27 @@ class TestZookeeperFeedPlan:
         assert plan.feed_plan == expected_plan
 
 
-class TestZooFeedingAlgorithm:
+class TestZooFeedAlgorithm:
 
     def test__repr__(self, feedable_pets_zoo: Zoo,
                      filled_stockpile: FoodStockpile):
-        algorithm = ZooFeedingAlgorithm(zoo=feedable_pets_zoo, stockpile=filled_stockpile)
+        algorithm = ZooFeedAlgorithm(zoo=feedable_pets_zoo, stockpile=filled_stockpile)
 
         repr_before: str = repr(algorithm)
         plan: ZookeeperFeedPlan = algorithm.make_plan()
         repr_after: str = repr(algorithm)
 
-        before_expected = "ZooFeedingAlgorithm(\n  __zookeeper_plan=\n)"
+        before_expected = "ZooFeedAlgorithm(\n  __zookeeper_plan=\n)"
         assert repr_before == before_expected
 
-        after_expected = f"ZooFeedingAlgorithm(\n  __zookeeper_plan={plan.format_plan()}\n)"
+        after_expected = f"ZooFeedAlgorithm(\n  __zookeeper_plan={plan.format_plan()}\n)"
         assert repr_after == after_expected
 
     def test_make_plan_empty_stockpile_results_in_empty_plan_ok(self,
                                                                 empty_zoo,
                                                                 empty_stockpile):
-        algorithm = ZooFeedingAlgorithm(zoo=empty_zoo,
-                                        stockpile=empty_stockpile)
+        algorithm = ZooFeedAlgorithm(zoo=empty_zoo,
+                                     stockpile=empty_stockpile)
 
         plan: ZookeeperFeedPlan = algorithm.make_plan()
 
@@ -115,8 +115,8 @@ class TestZooFeedingAlgorithm:
     def test_make_plan_empty_stockpile_filled_zoo_results_in_empty_plan_ok(self,
                                                                            feedable_pets_zoo,
                                                                            empty_stockpile):
-        algorithm = ZooFeedingAlgorithm(zoo=feedable_pets_zoo,
-                                        stockpile=empty_stockpile)
+        algorithm = ZooFeedAlgorithm(zoo=feedable_pets_zoo,
+                                     stockpile=empty_stockpile)
 
         plan: ZookeeperFeedPlan = algorithm.make_plan()
 
@@ -127,8 +127,8 @@ class TestZooFeedingAlgorithm:
     def test_make_plan_filled_stockpile_empty_zoo_results_in_empty_plan_ok(self,
                                                                            empty_zoo,
                                                                            filled_stockpile):
-        algorithm = ZooFeedingAlgorithm(zoo=empty_zoo,
-                                        stockpile=filled_stockpile)
+        algorithm = ZooFeedAlgorithm(zoo=empty_zoo,
+                                     stockpile=filled_stockpile)
 
         plan: ZookeeperFeedPlan = algorithm.make_plan()
 
@@ -156,7 +156,7 @@ class TestZooFeedingAlgorithm:
             })
         )
 
-        algorithm = ZooFeedingAlgorithm(zoo=zoo, stockpile=start_stockpile)
+        algorithm = ZooFeedAlgorithm(zoo=zoo, stockpile=start_stockpile)
 
         result_plan: ZookeeperFeedPlan = algorithm.make_plan()
 
@@ -195,7 +195,7 @@ class TestZooFeedingAlgorithm:
         }})
         zoo: Zoo = ZooBuilder(user).build()
         stockpile: FoodStockpile = FoodStockpileBuilder().user(user).build()
-        algorithm = ZooFeedingAlgorithm(zoo=zoo, stockpile=stockpile)
+        algorithm = ZooFeedAlgorithm(zoo=zoo, stockpile=stockpile)
 
         feed_plan: ZookeeperFeedPlan = algorithm.make_plan()
 

--- a/src/tests/hoplalib/zoo/test_zoomodels.py
+++ b/src/tests/hoplalib/zoo/test_zoomodels.py
@@ -53,7 +53,7 @@ class TestZooBuilder:
         assert len(result_zoo) == 1
 
         result_pair: PetMountPair = result_zoo[animal_name]
-        assert result_pair.pet.pet_name == animal_name
+        assert result_pair.pet.name == animal_name
         assert result_pair.pet.feed_status == FeedStatus(feed_status)
         assert result_pair.mount_available()
         assert result_pair.pet_available() is False
@@ -79,7 +79,7 @@ class TestZooBuilder:
 
         assert len(zoo) == 1
         result_pair: PetMountPair = zoo[animal_name]
-        assert result_pair.pet.pet_name == animal_name
+        assert result_pair.pet.name == animal_name
         assert result_pair.pet.feed_status == FeedStatus(feed_status)
         assert result_pair.mount_available() is False
         assert result_pair.pet_available()
@@ -95,7 +95,7 @@ class TestZooHelper:
         def predicate(pair: PetMountPair) -> bool:
             # arbitrary filter function
             return pair.pet is not None and (
-                    pair.pet.pet_name == "Parrot-Base"
+                    pair.pet.name == "Parrot-Base"
                     or pair.mount_available()
                     or int(pair.pet.feed_status) == 27
             )

--- a/src/tests/hoplalib/zoo/test_zoomodels.py
+++ b/src/tests/hoplalib/zoo/test_zoomodels.py
@@ -8,12 +8,10 @@ from tests.testutils.user_test_utils import UserTestUtil
 
 class TestZooBuilder:
     def test__init__(self):
-        animal_name = "Wolf-Zombie"
-        feeding_status = 5
-        animal_name2 = "Deer-Base"
-        feeding_status2 = 10
+        animal_name, feed_status = "Wolf-Zombie", 5
+        animal_name2, feed_status2 = "Deer-Base", 10
 
-        pets_dict = {animal_name: feeding_status, animal_name2: feeding_status2}
+        pets_dict = {animal_name: feed_status, animal_name2: feed_status2}
         mounts_dict = {animal_name: True}
         user: HabiticaUser = UserTestUtil.user_with_zoo(pets=pets_dict, mounts=mounts_dict)
 
@@ -23,9 +21,8 @@ class TestZooBuilder:
         assert builder.mounts == mounts_dict
 
     def test__repr__(self):
-        animal_name = "Wolf-CottonCandyBlue"
-        feeding_status = 5
-        pets_dict = {animal_name: feeding_status}
+        animal_name, feed_status = "Wolf-CottonCandyBlue", 5
+        pets_dict = {animal_name: feed_status}
         mounts_dict = {animal_name: True}
         user: HabiticaUser = UserTestUtil.user_with_zoo(pets=pets_dict, mounts=mounts_dict)
 
@@ -57,7 +54,7 @@ class TestZooBuilder:
 
         result_pair: PetMountPair = result_zoo[animal_name]
         assert result_pair.pet.pet_name == animal_name
-        assert result_pair.pet.feeding_status == FeedStatus(feed_status)
+        assert result_pair.pet.feed_status == FeedStatus(feed_status)
         assert result_pair.mount_available()
         assert result_pair.pet_available() is False
 
@@ -75,15 +72,15 @@ class TestZooBuilder:
 
     def test_build_yes_pet_no_mount(self):
         animal_name = "Dragon-Skeleton"
-        feeding_status = 27
-        user = UserTestUtil.user_with_zoo(pets={animal_name: feeding_status})
+        feed_status = 27
+        user = UserTestUtil.user_with_zoo(pets={animal_name: feed_status})
 
         zoo: Zoo = ZooBuilder(user).build()
 
         assert len(zoo) == 1
         result_pair: PetMountPair = zoo[animal_name]
         assert result_pair.pet.pet_name == animal_name
-        assert result_pair.pet.feeding_status == FeedStatus(feeding_status)
+        assert result_pair.pet.feed_status == FeedStatus(feed_status)
         assert result_pair.mount_available() is False
         assert result_pair.pet_available()
 
@@ -100,7 +97,7 @@ class TestZooHelper:
             return pair.pet is not None and (
                     pair.pet.pet_name == "Parrot-Base"
                     or pair.mount_available()
-                    or int(pair.pet.feeding_status) == 27
+                    or int(pair.pet.feed_status) == 27
             )
 
         helper = ZooHelper(zoo)
@@ -148,7 +145,7 @@ class TestZooHelper:
         zoo: Zoo = ZooBuilder(user).build()
 
         def predicate(pet: Pet) -> bool:
-            return int(pet.feeding_status) < 9
+            return int(pet.feed_status) < 9
 
         helper = ZooHelper(zoo)
         filtered_zoo: Zoo = helper.filter_on_pet(predicate=predicate)

--- a/src/tests/hoplalib/zoo/test_zoomodels.py
+++ b/src/tests/hoplalib/zoo/test_zoomodels.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 from hopla.cli.groupcmds.get_user import HabiticaUser
-from hopla.hoplalib.zoo.foodmodels import FeedingStatus
+from hopla.hoplalib.zoo.foodmodels import FeedStatus
 from hopla.hoplalib.zoo.petmodels import Pet, PetMountPair
 from hopla.hoplalib.zoo.zoomodels import Zoo, ZooBuilder, ZooHelper
 from tests.testutils.user_test_utils import UserTestUtil
@@ -57,7 +57,7 @@ class TestZooBuilder:
 
         result_pair: PetMountPair = result_zoo[animal_name]
         assert result_pair.pet.pet_name == animal_name
-        assert result_pair.pet.feeding_status == FeedingStatus(feed_status)
+        assert result_pair.pet.feeding_status == FeedStatus(feed_status)
         assert result_pair.mount_available()
         assert result_pair.pet_available() is False
 
@@ -83,7 +83,7 @@ class TestZooBuilder:
         assert len(zoo) == 1
         result_pair: PetMountPair = zoo[animal_name]
         assert result_pair.pet.pet_name == animal_name
-        assert result_pair.pet.feeding_status == FeedingStatus(feeding_status)
+        assert result_pair.pet.feeding_status == FeedStatus(feeding_status)
         assert result_pair.mount_available() is False
         assert result_pair.pet_available()
 


### PR DESCRIPTION
- Rename FeedingStatus to FeedStatus
- Rename all related Feeding -> Feed
- Rename all Hatching->Hatch
- Use pet.name instead of pet.pet_name
- Turn mount_name and food_name into name
